### PR TITLE
#17 Missing Factories tutorial

### DIFF
--- a/docs/dotnet/DotNetTutorialAdvancedProjections.md
+++ b/docs/dotnet/DotNetTutorialAdvancedProjections.md
@@ -162,9 +162,9 @@ http://localhost:50353/api/example/cars?include=[Model,Make,Year,Color,Owner[Ful
 ]
 ```
 ## Factories
-With Factories it's possible to extract the projection class instantiation. You can either use a plain factory or one that takes an context object as input parameter. The big advantage of using a context object is, that the instantiation can be configured to it's needs.
+With Factories it's possible to extract the projection class instantiation. You can either use a plain factory or one that takes an context object as input parameter. The big advantage of using a context object is that the instantiation can be configured to its needs.
 
-In the following example the Employee model consists of a property that describes the employment type (eg. FullTime/PartTime). If this employment type is not explicitly requested, using the include parameter or by requesting the entire model, it depends on it's initial value. With a context-based factory, this value can be set according to the current configuration.
+In the following example the Employee model consists of a property that describes the employment type (eg. FullTime/PartTime). If this employment type is not explicitly requested, using the include parameter or by requesting the entire model, it depends on its initial value. With a context-based factory, this value can be set according to the current configuration.
 
 ```csharp
 public enum EmploymentType

--- a/docs/dotnet/DotNetTutorialAdvancedProjections.md
+++ b/docs/dotnet/DotNetTutorialAdvancedProjections.md
@@ -161,4 +161,80 @@ http://localhost:50353/api/example/cars?include=[Model,Make,Year,Color,Owner[Ful
     }
 ]
 ```
+## Factories
+With Factories it's possible to extract the projection class instantiation. You can either use a plain factory or one that takes an context object as input parameter. The big advantage of using a context object is, that the instantiation can be configured to it's needs.
 
+In the following example the Employee model consists of a property that describes the employment type (eg. FullTime/PartTime). If this employment type is not explicitly requested, using the include parameter or by requesting the entire model, it depends on it's initial value. With a context-based factory, this value can be set according to the current configuration.
+
+```csharp
+public enum EmploymentType
+{
+    Employed,
+    PartTime,
+    FullTime
+}
+```
+
+```csharp
+public class EmployeeProjection
+{
+	...
+	public EmploymentType Employment { get;set; }
+}
+```
+
+```csharp
+popcornConfig
+    .Map<Employee, EmployeeProjection>()
+    .AssignFactory<EmployeeProjection>((context) => EmployeeFactory(context))
+    .SetContext(new Dictionary<string, object>
+    {
+        ["defaultEmployment"] = EmploymentType.Employed
+	});
+
+...
+
+private EmployeeProjection EmployeeFactory(Dictionary<string, object> context)
+    {
+        return new EmployeeProjection
+        {
+            Employment = context["defaultEmployment"] as EmploymentType?
+        };
+    }
+```
+
+According to this context configuration every EmployeeProjection object will be instantiated with a Employment value of `EmploymentType.Employed`.
+Requesting only FirstName and LastName will provide us with a default EmploymentType:
+```javascript
+http://localhost:35632/api/example/employees?include=[FirstName,LastName]
+
+[
+    {
+        "FirstName": "Liz",
+        "LastName": "Lemon",
+        "Employment": "Employed"
+    },
+    {
+        "FirstName": "Jack",
+        "LastName": "Donaghy",
+        "Employment": "Employed"
+    }
+]
+```
+
+By including the Employment property in the request, you'll get the exact EmploymentTypes.
+```javascript
+http://localhost:35632/api/example/employees?include=[FirstName,LastName,Employment]
+ [
+	{
+		"FirstName": "Liz",
+        "LastName": "Lemon",
+        "Employment": "FullTime"
+     },
+     {
+		"FirstName": "Jack",
+        "LastName": "Donaghy",
+        "Employment": "PartTime"
+     }
+]
+```

--- a/dotnet/PopcornCoreExample/Models/Employee.cs
+++ b/dotnet/PopcornCoreExample/Models/Employee.cs
@@ -9,6 +9,7 @@ namespace PopcornCoreExample.Models
         public string LastName { get; set; }
 
         public DateTimeOffset Birthday { get; set; }
+        public EmploymentType Employment { get; set; }
         public int VacationDays { get; set; }
 
         public List<Car> Vehicles { get; set; }

--- a/dotnet/PopcornCoreExample/Models/EmploymentType.cs
+++ b/dotnet/PopcornCoreExample/Models/EmploymentType.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace PopcornCoreExample.Models
+{
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum EmploymentType
+    {
+        Employed,
+        PartTime,
+        FullTime
+    }
+}

--- a/dotnet/PopcornCoreExample/Projections/EmployeeProjection.cs
+++ b/dotnet/PopcornCoreExample/Projections/EmployeeProjection.cs
@@ -1,4 +1,5 @@
-﻿using Skyward.Popcorn;
+﻿using PopcornCoreExample.Models;
+using Skyward.Popcorn;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,6 +17,7 @@ namespace PopcornCoreExample.Projections
 
         public string Birthday { get; set; }
         public int? VacationDays { get; set; }
+        public EmploymentType? Employment { get; set; }
 
         [SubPropertyIncludeByDefault("[Make,Model,Color]")]
         public List<CarProjection> Vehicles { get; set; }

--- a/dotnet/PopcornCoreExample/Startup.cs
+++ b/dotnet/PopcornCoreExample/Startup.cs
@@ -51,15 +51,25 @@ namespace PopcornCoreExample
                                 // The car parameter is the source object; the context parameter is the dictionary we configure below.
                                 (context["database"] as ExampleContext).Employees.FirstOrDefault(e => e.Vehicles.Contains(car)));
                         })
+                        .AssignFactory<EmployeeProjection>((context) => EmployeeFactory(context))
                         // Pass in our 'database' via the context
                         .SetContext(new Dictionary<string, object>
                         {
-                            ["database"] = database
+                            ["database"] = database,
+                            ["defaultEmployment"] = EmploymentType.Employed
                         });
                 });
             });
         }
         
+        private EmployeeProjection EmployeeFactory(Dictionary<string, object> context)
+        {
+            return new EmployeeProjection
+            {
+                Employment = context["defaultEmployment"] as EmploymentType?
+            };
+        }
+
         private ExampleContext CreateExampleDatabase()
         {
             var context = new ExampleContext();
@@ -67,6 +77,7 @@ namespace PopcornCoreExample
             {
                 FirstName = "Liz",
                 LastName = "Lemon",
+                Employment = EmploymentType.FullTime,
                 Birthday = DateTimeOffset.Parse("1981-05-01"),
                 VacationDays = 0,
                 Vehicles = new List<Car>()
@@ -86,6 +97,7 @@ namespace PopcornCoreExample
             {
                 FirstName = "Jack",
                 LastName = "Donaghy",
+                Employment = EmploymentType.PartTime,
                 Birthday = DateTimeOffset.Parse("1957-07-12"),
                 VacationDays = 300,
                 Vehicles = new List<Car>()

--- a/dotnet/PopcornStandardTest/ExpanderTests.cs
+++ b/dotnet/PopcornStandardTest/ExpanderTests.cs
@@ -179,6 +179,18 @@ namespace PopcornStandardTest
             public string ShouldBeEmpty { get; set; }
         }
 
+        public class EntityFromContextBasedFactory
+        {
+            public string MappedString { get; set; }
+            public string ContextString { get; set; }
+        }
+
+        public class EntityFromContextBasedFactoryProjection
+        {
+            public string MappedString { get; set; }
+            public string ContextString { get; set; }
+        }
+
         public class NonMappedType
         {
             public string Name { get; set; }
@@ -204,7 +216,9 @@ namespace PopcornStandardTest
             config.Map<DerivedChildObject, DerivedChildObjectProjection>();
             config.Map<Loop, LoopProjection>();
             config.Map<EntityFromFactory, EntityFromFactoryProjection>();
+            config.Map<EntityFromContextBasedFactory, EntityFromContextBasedFactoryProjection>();
             config.AssignFactory<EntityFromFactoryProjection>(() => new EntityFromFactoryProjection { ShouldBeEmpty = "Generated" });
+            config.AssignFactory<EntityFromContextBasedFactoryProjection>((context) => new EntityFromContextBasedFactoryProjection{ ContextString = context["DefaultString"] as string, MappedString = context["DefaultString"] as string });
         }
 
         // Things to test
@@ -933,6 +947,19 @@ namespace PopcornStandardTest
 
             var entityProjection = result as EntityFromFactoryProjection;
             entityProjection.ShouldBeEmpty.ShouldBe("Generated");
+        }
+
+        [TestMethod]
+        public void CreateWithContextBasedTypeFactory()
+        {
+            var entity = new EntityFromContextBasedFactory() { MappedString = "Some Text" };
+            var context = new Dictionary<string, object> { { "DefaultString", "SpecifiedByContext" } };
+            var result = _expander.Expand(entity, context, PropertyReference.Parse($"[MappedString]"));
+            result.ShouldNotBeNull();
+
+            var entityProjection = result as EntityFromContextBasedFactoryProjection;
+            entityProjection.MappedString.ShouldNotBe("SpecifiedByContext");
+            entityProjection.ContextString.ShouldBe("SpecifiedByContext");
         }
 
         [TestMethod]


### PR DESCRIPTION
Resolved by implementing the 3 requirements from issue #17 

- Test added to ExpanderTests.cs
- Example added to PopcornExample project
- Tutorial added to AdvancedProjections

## Description
- The Test checks if the context based factory works
  - Already specified properties should keep their value
  - All the others should show their initial value (specified by factory)
- EmploymentType example added (see DotNetTutorialAdvancedProjections.md)

## Related Issue
#17 

## Motivation and Context
#17