### PR TITLE
Added [InternalOnly] attribute

### DIFF
--- a/dotnet/PopcornNetStandard/Externals/Expander.cs
+++ b/dotnet/PopcornNetStandard/Externals/Expander.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using static System.Reflection.TypeExtensions;
 
 namespace Skyward.Popcorn
 {
@@ -119,6 +120,17 @@ namespace Skyward.Popcorn
 
             if (visited == null)
                 visited = new HashSet<int>();
+
+            // Check if the source class is marked as InternalOnly
+            var customAttr = sourceType.GetTypeInfo().GetCustomAttribute<InternalOnlyAttribute>();
+            if (customAttr != null)
+            {
+
+                if (customAttr.ThrowExcepton)
+                    throw new InternalOnlyViolationException();
+
+                return null;
+            }
 
             // See if this is a directly expandable type (Mapped Type)
             if (WillExpandDirect(sourceType))

--- a/dotnet/PopcornNetStandard/Internals/Attributes/InternalOnly.cs
+++ b/dotnet/PopcornNetStandard/Internals/Attributes/InternalOnly.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Skyward.Popcorn
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method |AttributeTargets.Property,AllowMultiple = false, Inherited = true )]
+    public class InternalOnlyAttribute : Attribute
+    {
+        private bool throwException;
+
+        public InternalOnlyAttribute(bool throwException = true)
+        {
+            this.throwException = throwException;
+        }
+
+        public bool ThrowExcepton { get { return throwException; } }
+
+    }
+
+}

--- a/dotnet/PopcornNetStandard/Internals/Exceptions/InternalOnlyViolationException.cs
+++ b/dotnet/PopcornNetStandard/Internals/Exceptions/InternalOnlyViolationException.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Skyward.Popcorn
+{
+    public class InternalOnlyViolationException : Exception
+    {
+
+        public InternalOnlyViolationException()
+        {
+        }
+
+        public InternalOnlyViolationException(string message) : base(message)
+        {
+        }
+
+        public InternalOnlyViolationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/dotnet/PopcornNetStandard/Internals/Expander+Expand.cs
+++ b/dotnet/PopcornNetStandard/Internals/Expander+Expand.cs
@@ -283,6 +283,20 @@ namespace Skyward.Popcorn
             var matchingProperty = sourceType.GetTypeInfo().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
             var matchingMethod = sourceType.GetTypeInfo().GetMethod(propertyName, BindingFlags.Instance | BindingFlags.Public);
 
+            // Check if the value is marked as InternalOnly
+            InternalOnlyAttribute[] attributes = new InternalOnlyAttribute[2];
+            attributes[0] = matchingProperty?.GetCustomAttribute<InternalOnlyAttribute>();
+            attributes[1] = matchingMethod?.GetCustomAttribute<InternalOnlyAttribute>();
+            foreach(var internalOnlyAttr in attributes)
+            {
+                if (internalOnlyAttr == null)
+                    continue;
+                if (internalOnlyAttr.ThrowExcepton)
+                    throw new InternalOnlyViolationException();
+
+                return null;
+            }
+
             // if there's a custom entry for this, it gets first crack
             if (translators != null && translators.ContainsKey(propertyName))
             {
@@ -308,6 +322,8 @@ namespace Skyward.Popcorn
                 // Couldn't map it, but it was explicitly requested, so throw an error
                 throw new InvalidCastException(propertyName);
             }
+
+
 
             return valueToAssign;
         }
@@ -459,6 +475,7 @@ namespace Skyward.Popcorn
         /// <returns></returns>
         private bool SetValueToProperty(object originalValue, PropertyInfo destinationProperty, object destinationObject, ContextType context, PropertyReference propertyReference, HashSet<int> visited)
         {
+
             // If it is null then just do a direct assignment
             if (originalValue == null)
             {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added [InternalOnly] attribute. 
If the client tries to expand an object or to read a property or value marked [InternalOnly(true)], it will throw an exception. If marked InternalOnly(false) it will return null instead.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#34 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#34 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created a few Unit Tests inside the ExpanderTests.cs file. Every test was passed.
