### PR TITLE
Added [ExpandFrom] attribute

### DIFF
--- a/dotnet/PopcornNetStandard/Externals/PopcornConfiguration.cs
+++ b/dotnet/PopcornNetStandard/Externals/PopcornConfiguration.cs
@@ -206,6 +206,10 @@ namespace Skyward.Popcorn
             return this;
         }
 
+        /// <summary>
+        /// Maps all the types marked with ExpandFrom inside the given assembly
+        /// </summary>
+        /// <param name="assembly">The aseembly to seearch in</param>
         public void ScanAssemblyForMapping(Assembly assembly)
         {
             MethodInfo method = typeof(PopcornConfiguration).GetMethod("Map");

--- a/dotnet/PopcornNetStandard/Externals/PopcornConfiguration.cs
+++ b/dotnet/PopcornNetStandard/Externals/PopcornConfiguration.cs
@@ -205,5 +205,21 @@ namespace Skyward.Popcorn
             _expander.ExpandBlindObjects = v;
             return this;
         }
+
+        public void ScanAssemblyForMapping(Assembly assembly)
+        {
+            MethodInfo method = typeof(PopcornConfiguration).GetMethod("Map");
+
+            foreach (Type type in assembly.GetTypes())
+            {
+                var attr = type.GetTypeInfo().GetCustomAttribute<ExpandFromAttribute>();
+                if (attr == null)
+                    continue;
+
+                MethodInfo generic = method.MakeGenericMethod(attr.SourceType, type);
+                object[] parameters = { attr.Includes, null};
+                generic.Invoke(this, parameters);
+            }
+        }
     }
 }

--- a/dotnet/PopcornNetStandard/Internals/Attributes/ExpandFrom.cs
+++ b/dotnet/PopcornNetStandard/Internals/Attributes/ExpandFrom.cs
@@ -4,6 +4,9 @@ using System.Text;
 
 namespace Skyward.Popcorn
 {
+    /// <summary>
+    /// This attribute is used to mark classes for automatic Mapping by PopcornConfiguration
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
     public class ExpandFromAttribute : Attribute
     {

--- a/dotnet/PopcornNetStandard/Internals/Attributes/ExpandFrom.cs
+++ b/dotnet/PopcornNetStandard/Internals/Attributes/ExpandFrom.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Skyward.Popcorn
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ExpandFromAttribute : Attribute
+    {
+        Type source;
+        string includes;
+
+        public ExpandFromAttribute(Type source, string includes)
+        {
+            this.source = source;
+            this.includes = includes;
+        }
+
+        public Type SourceType { get { return source; } }
+        public string Includes { get { return includes; } }
+    }
+}

--- a/dotnet/PopcornNetStandardTest/MultipleProjectionTests.cs
+++ b/dotnet/PopcornNetStandardTest/MultipleProjectionTests.cs
@@ -4,6 +4,7 @@ using Skyward.Popcorn;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace PopcornNetStandardTest
 {
@@ -75,6 +76,22 @@ namespace PopcornNetStandardTest
             public List<UserWithNameProjection> Users1 { get; set; }
             public List<UserWithEmailProjection> Users2 { get; set; }
         }
+
+        class ExpandFromClass
+        {
+            public string Field1 { get; set; }
+            public int Field2 { get; set; }
+        }
+
+        [ExpandFrom(typeof(ExpandFromClass), "[Field1,Field2]")]
+        class ExpandFromClassProjection
+        {
+            public string Field1 { get; set; }
+            public int Field2 { get; set; }
+        }
+
+
+
 
         #endregion
         #endregion
@@ -209,6 +226,20 @@ namespace PopcornNetStandardTest
             collectionProjected.Users2.ShouldNotBeNull();
             collectionProjected.Users2.Count.ShouldBe(2);
             collectionProjected.Users2.All(u => u.Email == TestEmail).ShouldBeTrue();
+        }
+
+        [TestMethod]
+        public void ExpandFromTest()
+        {
+            var expander = new Expander();
+            var config = new PopcornConfiguration(expander);
+            config.ScanAssemblyForMapping(this.GetType().GetTypeInfo().Assembly);
+
+            ExpandFromClass testObject = new ExpandFromClass { Field1 = "field1", Field2 = 2 };
+            var result = (ExpandFromClassProjection)expander.Expand(testObject, null);
+            Assert.AreEqual(testObject.Field1, result.Field1);
+            Assert.AreEqual(testObject.Field2, result.Field2);
+
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the ExpandFrom attribute and ScanAssemblyForMapping method.
If a class is marked with ExpandFrom, it will be automatically mapped when ScanAssemblyForMapping is called.

Usage example:
```
class Car { ... }
[ExpandFrom(typeof(Car), "[Field1,Field2]"]
class CarProjection{ ... }
...
var assembly1 = ... ; //probably reflection calls
var assembly2 = ... ;
var expander = new Expander();
var config = new PopcornConfiguration(expander);
config.ScanAssemblyForMapping(assembly1);
config.ScanAssemblyForMapping(assembly2);
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#33 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#33 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit Test inside the tests file.

