### PR TITLE
Allow optional parameter for ExpandResultAttribute

### DIFF
--- a/dotnet/PopcornNetFramework.WebApi/PopcornExtensions.cs
+++ b/dotnet/PopcornNetFramework.WebApi/PopcornExtensions.cs
@@ -33,13 +33,19 @@ namespace PopcornNetFramework.WebApi
         {
             if (!_expandAllEndpoints)
             {
-                var expandAttribute = context.ActionContext
+                var filterDescriptor = context.ActionContext
                     .ActionDescriptor
                     .GetFilters()
                     .SingleOrDefault(f => f.GetType() == typeof(ExpandResultAttribute));
 
-                if (expandAttribute == null)
+                //Cast the filter to ExpandResultAttribute
+                var attributeInstance = filterDescriptor as ExpandResultAttribute;
+
+                //If the attribute is null, i.e. not present, or false, it shouldn't expand and we return here
+                if (!(attributeInstance?.ShouldExpand ?? false))
+                {
                     return;
+                }
             }
 
             var doNotExpandAttribute = context.ActionContext
@@ -142,17 +148,30 @@ namespace PopcornNetFramework.WebApi
     }
 
     /// <summary>
-    /// Apply this attribute to ensure a result is always expanded
+    /// Apply this attribute to ensure a result is always expanded or optionally pass a boolean specifying behaviour
     /// </summary>
     public class ExpandResultAttribute : ActionFilterAttribute
     {
+        public bool ShouldExpand { get; private set; }
+        /// <summary>
+        /// Apply this attribute to specify whether a result is to always expand or never expand
+        /// </summary>
+        /// <param name="shouldExpand">Defaults to <c>true</c>. If set to false, result will not be expanded. If passing <c>false</c>, you can also use <seealso cref="DoNotExpandResultAttribute"/></param>
+        public ExpandResultAttribute(bool shouldExpand = true)
+        {
+            ShouldExpand = shouldExpand;
+        }
     }
 
     /// <summary>
     /// Apply this attribute to ensure a result is never expanded
     /// </summary>
-    public class DoNotExpandResultAttribute : ActionFilterAttribute
+    public class DoNotExpandResultAttribute : ExpandResultAttribute
     {
+        public DoNotExpandResultAttribute() : base(false)
+        {
+
+        }
     }
 
     /// <summary>

--- a/dotnet/PopcornNetStandard.WebApiCore/ExpandResultAttribute.cs
+++ b/dotnet/PopcornNetStandard.WebApiCore/ExpandResultAttribute.cs
@@ -31,13 +31,19 @@ namespace Skyward.Popcorn
 
             if (!_expandAllEndpoints)
             {
-                var expandAttribute = context
+                var filterDescriptor = context
                     .ActionDescriptor
                     .FilterDescriptors
                     .SingleOrDefault(d => d.Filter.GetType() == typeof(ExpandResultAttribute));
 
-                if (expandAttribute == null)
+                //Cast the filter property to ExpandResultAttribute
+                var attributeInstance = filterDescriptor?.Filter as ExpandResultAttribute;
+
+                //If the attribute is null, i.e. not present, or false, it shouldn't expand and we return here
+                if (!(attributeInstance?.ShouldExpand ?? false))
+                {
                     return;
+                }
             }
 
             var doNotExpandAttribute = context
@@ -130,7 +136,7 @@ namespace Skyward.Popcorn
                 {
                     NullValueHandling = NullValueHandling.Ignore
                 });
-            
+
         }
 
         public void OnActionExecuting(ActionExecutingContext context)
@@ -139,17 +145,30 @@ namespace Skyward.Popcorn
     }
 
     /// <summary>
-    /// Apply this attribute to ensure a result is always expanded
+    /// Apply this attribute to ensure a result is always expanded or optionally pass a boolean specifying behaviour
     /// </summary>
     public class ExpandResultAttribute : ActionFilterAttribute
     {
+        public bool ShouldExpand { get; private set; }
+        /// <summary>
+        /// Apply this attribute to specify whether a result is to always expand or never expand
+        /// </summary>
+        /// <param name="shouldExpand">Defaults to <c>true</c>. If set to false, result will not be expanded. If passing <c>false</c>, you can also use <seealso cref="DoNotExpandResultAttribute"/></param>
+        public ExpandResultAttribute(bool shouldExpand = true)
+        {
+            ShouldExpand = shouldExpand;
+        }
     }
 
     /// <summary>
     /// Apply this attribute to ensure a result is never expanded
     /// </summary>
-    public class DoNotExpandResultAttribute : ActionFilterAttribute
+    public class DoNotExpandResultAttribute : ExpandResultAttribute
     {
+        public DoNotExpandResultAttribute() : base(false)
+        {
+
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Description
Allows for `ExpandResultAttribute` to accept an optional boolean parameter for specifying behavior, to expand result or to not expand result, which is then set as the value of the `ExpandResultAttribute.ShouldExpand` property.
`DoNotExpandResultAttribute` now inherits from `ExpandResultAttribute` but always passing in `false`.
The `ExpandActionFilter` has been updated to accommodate if `ExpandResultAttribute.ShouldExpand` is set to `false`.

## Related Issue
[Relevant issue](https://github.com/SkywardApps/popcorn/issues/32)

## Motivation and Context
[Relevant issue](https://github.com/SkywardApps/popcorn/issues/32)

## How Has This Been Tested?
Tested with example projects. The attributes still have the same types (and default behavior) and won't break any code looking at the attribute types, if developers have custom logic written towards the types. 
## Screenshots (if appropriate):
