### PR TITLE
Wire release workflow + refresh docs for v8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,40 +1,140 @@
-name: Build and Publish Package
+name: Release
+
+# Triggered by pushing a tag of the form `release/vX.Y.Z` (or `release/vX.Y.Z-suffix`)
+# to master. The tag is the single source of truth for the version: we pack both
+# v8 packages with that version (overriding the csproj <Version> via -p:Version=),
+# push them to NuGet, create a GitHub Release with the .nupkg + .snupkg attached,
+# and sync the csproj <Version> on master so the next dev build starts from a
+# matching baseline.
+#
+# The csproj sync is best-effort — if branch protection blocks the push, the release
+# still succeeds; a maintainer can bump the csproj manually after the fact.
+#
+# Prior iteration of this file had a broken regex-style tag filter (`/^release/`)
+# that never matched any glob, so the pipeline never actually ran. If anyone on the
+# team "published v8 manually before," this is why.
 
 on:
   push:
     tags:
-      - /^release/
+      - 'release/v*'
+
+permissions:
+  contents: write  # needed for `gh release create` and for the version-sync push
 
 jobs:
-  build-and-push-package:
-    name: Pack and push v8 packages to NuGet
-
+  release:
+    name: Pack, publish to NuGet, create GitHub release
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
-      - name: Checkout code
+      - name: Checkout tagged commit
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # SourceLink needs full history to resolve commit hashes.
+          fetch-depth: 0  # SourceLink needs full history to resolve commit hashes
 
-      - name: Setup dotnet
+      - name: Extract version from tag
+        id: ver
+        run: |
+          # Tag: refs/tags/release/v8.0.0           → version 8.0.0
+          # Tag: refs/tags/release/v8.1.0-preview.1 → version 8.1.0-preview.1
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#release/v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::Tag '$TAG' is not in the expected format release/vX.Y.Z[-suffix]"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Setup .NET SDK 8.0
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8
+          dotnet-version: 8.0.x
 
-      # v8 only. The legacy v7 packages (Skyward.Api.Popcorn +
-      # Skyward.Api.Popcorn.DotNetCore) are no longer published from this repo — the
-      # last v7 release was shipped from master and will remain on NuGet for install
-      # compatibility, but new work happens only on v8 (Skyward.Api.Popcorn.SourceGen +
-      # Skyward.Api.Popcorn.SourceGen.Shared).
-      - name: Package SourceGen.Shared
-        run: cd dotnet && dotnet pack -c ${PublishConfiguration:-Release} --output ../publish Popcorn.Shared/Popcorn.Shared.csproj
+      # -p:Version= and -p:PackageVersion= together make the emitted .nupkg carry the
+      # tag's version regardless of what <Version> the csproj has. The csproj edit
+      # (later step) is for keeping the repo tidy, not for the pack output.
+      - name: Pack Popcorn.Shared
+        working-directory: dotnet
+        run: >
+          dotnet pack Popcorn.Shared/Popcorn.Shared.csproj
+          -c Release
+          -p:Version=${{ steps.ver.outputs.version }}
+          -p:PackageVersion=${{ steps.ver.outputs.version }}
+          --output ../publish
 
-      - name: Package SourceGen
-        run: cd dotnet && dotnet pack -c ${PublishConfiguration:-Release} --output ../publish Popcorn.SourceGenerator/Popcorn.SourceGenerator.csproj
+      - name: Pack Popcorn.SourceGenerator
+        working-directory: dotnet
+        run: >
+          dotnet pack Popcorn.SourceGenerator/Popcorn.SourceGenerator.csproj
+          -c Release
+          -p:Version=${{ steps.ver.outputs.version }}
+          -p:PackageVersion=${{ steps.ver.outputs.version }}
+          --output ../publish
 
-      # `|| :` tolerates version-conflict re-runs (same tag, re-pushed).
-      - name: Publish Packages
+      - name: List packaged artifacts
+        run: ls -la publish/
+
+      # `dotnet nuget push *.nupkg` automatically pushes the sibling .snupkg symbol
+      # package if one exists, so a single loop over *.nupkg is enough.
+      # `--skip-duplicate` replaces the old `|| :` hack: if someone re-runs a release
+      # (same tag, re-push), we don't fail on "already exists."
+      - name: Push packages to NuGet
         env:
-          SKYWARDNUGETAPIKEY: ${{ secrets.SKYWARDNUGETAPIKEY }}
-        run: cd publish && for fileName in *.nupkg; do echo ${fileName}; dotnet nuget push -k "$SKYWARDNUGETAPIKEY" -s https://api.nuget.org/v3/index.json ${fileName} || :; done
+          NUGET_API_KEY: ${{ secrets.SKYWARDNUGETAPIKEY }}
+        working-directory: publish
+        run: |
+          if [ -z "$NUGET_API_KEY" ]; then
+            echo "::error::Secret SKYWARDNUGETAPIKEY is not set — cannot push to NuGet."
+            exit 1
+          fi
+          for pkg in *.nupkg; do
+            echo "Pushing $pkg"
+            dotnet nuget push "$pkg" \
+              -k "$NUGET_API_KEY" \
+              -s https://api.nuget.org/v3/index.json \
+              --skip-duplicate
+          done
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "v${{ steps.ver.outputs.version }}" \
+            --generate-notes \
+            publish/*.nupkg publish/*.snupkg
+
+      # Sync the csproj <Version> on master so the next dev build reads a version
+      # that matches the latest release. Best-effort: branch protection may reject
+      # the push, in which case we log a warning and the release still succeeds.
+      - name: Sync csproj version on master
+        continue-on-error: true
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          git fetch origin master
+          git checkout master
+          changed=0
+          for f in dotnet/Popcorn.Shared/Popcorn.Shared.csproj dotnet/Popcorn.SourceGenerator/Popcorn.SourceGenerator.csproj; do
+            current=$(grep -oP '(?<=<Version>)[^<]+' "$f" | head -n 1)
+            if [ "$current" != "$VERSION" ]; then
+              echo "Bumping $f: $current → $VERSION"
+              sed -i "s|<Version>${current}</Version>|<Version>${VERSION}</Version>|" "$f"
+              changed=1
+            else
+              echo "$f already at $VERSION"
+            fi
+          done
+          if [ "$changed" = "1" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add dotnet/Popcorn.Shared/Popcorn.Shared.csproj dotnet/Popcorn.SourceGenerator/Popcorn.SourceGenerator.csproj
+            git commit -m "Sync csproj Version to ${VERSION} after ${GITHUB_REF_NAME} release [skip ci]"
+            if ! git push origin master; then
+              echo "::warning::Could not push version bump to master. Branch protection may be blocking workflow pushes. Bump csproj <Version> manually."
+              exit 0
+            fi
+          fi

--- a/README.md
+++ b/README.md
@@ -1,33 +1,45 @@
 <img src="/media/PopcornLogo.png" width="50%">
+
 # Popcorn
 
-[![Join the chat at https://gitter.im/popcorn-api/Lobby](https://badges.gitter.im/popcorn-api/Lobby.svg)](https://gitter.im/popcorn-api/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build status](https://ci.appveyor.com/api/projects/status/odjc31j0q0k213qh/branch/master?svg=true)](https://ci.appveyor.com/project/alexbarbato/popcorn/branch/master) 
-[![NuGet](https://img.shields.io/nuget/v/Skyward.Api.Popcorn.svg)](https://www.nuget.org/packages/Skyward.Api.Popcorn)
+[![NuGet (v8 preview)](https://img.shields.io/nuget/vpre/Skyward.Api.Popcorn.SourceGen.Shared?label=v8%20preview)](https://www.nuget.org/packages/Skyward.Api.Popcorn.SourceGen.Shared)
+[![NuGet (v7)](https://img.shields.io/nuget/v/Skyward.Api.Popcorn?label=v7%20stable)](https://www.nuget.org/packages/Skyward.Api.Popcorn)
+[![Tests](https://github.com/SkywardApps/popcorn/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/SkywardApps/popcorn/actions/workflows/tests.yml)
+[![AOT CI](https://github.com/SkywardApps/popcorn/actions/workflows/aot-ci.yml/badge.svg?branch=master)](https://github.com/SkywardApps/popcorn/actions/workflows/aot-ci.yml)
 
 [Table Of Contents](docs/TableOfContents.md)
+
+> **Quick orientation.** Popcorn v8 (the current active line) is a Roslyn **source generator**.
+> The older v7 packages (still on NuGet) were built on **runtime reflection**. The two are
+> side-by-side installable and 100% wire-compatible — same `?include=` grammar, same attribute
+> semantics. The source-gen rewrite exists so Popcorn can run under `PublishAot=True` and
+> `PublishTrimmed=True`, which reflection can't. New projects: start with v8. Existing
+> projects on v7: see [Migrating from v7 to v8](docs/MigrationV7toV8.md) — the migration is
+> mostly find-and-replace.
+
 ## Jump straight in
-+ **.NET Core** - We have a [.net core middleware](docs/dotnet/DotNetDocumentation.md) that you can drop in to enable Popcorn on Web Apis. 
-Feel free to grab it on [nuget](https://www.nuget.org/packages/Skyward.Api.Popcorn.DotNetCore).
-+ **Other implementations** - See our [Roadmap](docs/Roadmap.md) or issues on GitHub for coming work
+
++ **New in .NET?** [DotNet Quick Start](docs/dotnet/DotNetQuickStart.md) — drop Popcorn v8 into a minimal-API app in five minutes.
++ **Migrating from v7?** [Migration guide](docs/MigrationV7toV8.md) — attribute renames, startup config changes, dropped features.
++ **Curious about numbers?** [Performance](docs/Performance.md) — benchmarked vs raw System.Text.Json and v7 reflection.
++ **Other platforms?** The protocol is platform-agnostic; only .NET has a provider today. See [Roadmap](roadmap.md).
 
 ## What is Popcorn?
-Popcorn is a communication protocol on top of a RESTful API that allows requesting clients to 
+
+Popcorn is a communication protocol on top of a RESTful API that allows requesting clients to
 identify individual fields of resources to include when retrieving the resource or resource
 collection.
 
-It allows for a recursive selection of fields, allowing multiple calls to be condensed 
-into one.  
+It allows for a recursive selection of fields, allowing multiple calls to be condensed
+into one.
 
-### Features
-+ Selective inclusion from a RESTful API
-	+ Configurable [response defaults](docs/dotnet/DotNetTutorialDefaultIncludes.md)
-	+ [Sorting](docs/dotnet/DotNetTutorialSorting.md) of responses
-	+ Selective [authorization](docs/dotnet/DotNetTutorialAuthorizers.md) and [permissioning](docs/dotnet/DotNetTutorialInternalOnly.md) of response values
-	+ Configurable [response inspectors](docs/dotnet/DotNetTutorialInspectors.md)
-	+ [Factory and advanced projection](docs/dotnet/DotNetTutorialAdvancedProjections.md) support
-	+ Set relevant [contexts](docs/dotnet/DotNetTutorialContexts.md) for your API
-	+ [Blind expansion](docs/dotnet/DotNetTutorialBlindExpansion.md) of response objects
+### Features (v8)
+
++ Selective field inclusion via `?include=[Field,Nested[Field]]` — one round trip instead of N.
++ Configurable [response defaults](docs/dotnet/DotNetTutorialDefaultIncludes.md) via `[Default]` / `[Always]` / `[Never]` attributes.
++ [Custom response envelopes](docs/MigrationV7toV8.md#6-custom-response-envelope--error-handling) via marker attributes + generator-emitted exception middleware.
++ Works under `PublishAot=True` and `PublishTrimmed=True`. No runtime reflection on the hot path.
++ Beats raw `System.Text.Json` on complex nested data (0.87× time / 0.93× alloc when emitting everything; ~10× faster and ~10× less alloc on selective fetch).
 
 **Ok, so.... what is it in action?**
 
@@ -129,48 +141,54 @@ Presto! All the information we wanted at our fingertips, and none of the data we
 
 ## Why would I use it?
 
-By implementing the Popcorn protocol, you get a consistent, well defined API abstraction that your
-API consumers will be able to easily utilize.  You will be able to take advantage of the various
-libraries and tools Popcorn offers; right now this includes a C# automatic implementation for 
-Asp.Net Core and EntityFramework Core, but many more platforms are on the roadmap.
+By implementing the Popcorn protocol, you get a consistent, well-defined API abstraction that your
+API consumers can easily utilize. Right now this ships as a C# library for ASP.NET Core with
+`System.Text.Json`; the protocol itself is platform-agnostic and other providers are welcome.
 
 ### Pros
-+ Faster calls
-+ Saves data
-+ Potential for server-side optimization
-+ Less boilerplate code to write
++ Fewer round trips for nested data.
++ Smaller payloads — server never materializes fields the client isn't going to read.
++ AOT- and trim-safe (v8) — your Popcorn-enabled service can publish to a single native binary.
++ Plain REST + JSON — no new client runtime, visible in the URL, cacheable by HTTP-standard tooling.
 
 ### Cons
-+ You don't get to write as much code
-+ Your consumers don't get to write as much code
++ `?include=[...]` is a new grammar clients must learn (though it's easy — see [Include Parameter Syntax](docs/dotnet/DotNetTutorialIncludeParameterSyntax.md)).
++ If you need typed client generation (OpenAPI, etc.), you'll need extra tooling — the shape of a response depends on the request.
 
-## Performance
+## A short history (reflection → source generator)
 
-The upcoming v2 (.NET source-generator) build has been benchmarked against both the v1 reflection
-engine and raw `System.Text.Json`.  Highlights (vs raw STJ, on a 25-item list of complex nested
-objects):
+Popcorn v1 through v7 (on NuGet as `Skyward.Api.Popcorn` / `.DotNetCore`) implemented selective
+serialization with **runtime reflection**: at request time the library walked the response
+object, read `[IncludeByDefault]` / `[InternalOnly]` attributes, and built a filtered
+`Dictionary<string, object?>` before handing it to the JSON serializer. That worked well on
+classic ASP.NET Core but became a blocker for newer .NET deployment stories:
 
-+ When the client asks for a subset, v2 is **~10× faster and allocates ~10× less** than raw STJ.
-+ When the client asks for everything, v2 is **0.87× the time of raw STJ** — faster than STJ even
-  without using selectivity, with no "Popcorn tax" to pay for keeping the feature available.
-+ v2 beats the v1 legacy engine in every cell we measured — 3–8× on apples-to-apples "emit
-  everything" comparisons, ~5.8× on the selective-fetch case that matters most.
-+ v2 works under `PublishAot=True` and `PublishTrimmed=True` (no runtime reflection on the hot
-  path). v1 does not.
+- **Native AOT** (`PublishAot=True`) strips metadata the reflection path needs. Popcorn v7 cannot AOT-publish.
+- **IL trimming** (`PublishTrimmed=True`) removes reachable-but-reflection-only members.
+  Again, v7 loses.
+- **Overhead on every request** — reflection + intermediate dictionary allocations dominated
+  the hot path, especially for large nested responses.
 
-Full methodology, per-shape ratios, and reproduction instructions: **[Performance](docs/Performance.md)**.
+**Popcorn v8** is a rewrite on top of a Roslyn source generator. At build time the generator
+scans `[JsonSerializable(typeof(ApiResponse<T>))]` declarations, walks the type graph, and
+emits one straight-line `JsonConverter<T>` per reachable type — no reflection, no intermediate
+dictionary, no metadata the trimmer can strip. The wire protocol (`?include=` grammar, attribute
+semantics, `Pop<T>` envelope shape) is unchanged; only the internals and the extension-point API
+surface moved. See [Performance](docs/Performance.md) for the numbers and
+[Migrating from v7 to v8](docs/MigrationV7toV8.md) for the API changes.
+
+Both package lines are on NuGet side-by-side during the transition: grab v8 for new work,
+keep v7 if you aren't yet ready to migrate.
 
 ## How can I use it in my project?
 
-First you need to figure out if you're working with a platform that has a provider implemented in 
-the popcorn project. (Probably check out [Documentation](docs/Documentation.md)).
+**.NET (ASP.NET Core):** see the [.NET Quick Start](docs/dotnet/DotNetQuickStart.md) and the
+[Getting Started tutorial](docs/dotnet/DotNetTutorialGettingStarted.md). Both packages
+(`Skyward.Api.Popcorn.SourceGen` + `Skyward.Api.Popcorn.SourceGen.Shared`) are on NuGet.
 
-If there's a provider already in the project, great!  The platform-specific documentation will walk
-you though incorporating the provider into your project.
-
-If there isn't a provider yet, you'll have to roll your own.  You'll still get the benefit of 
-working with a standard, so your consumers will have a well documented spec to work with.  Feel free
-to contribute any platform-specific providers you come up with!
+**Other platforms:** the protocol is documented in [Documentation](docs/Documentation.md) — if
+you build a provider in another language, the `?include=` grammar and default/always/never
+semantics defined there are the contract you need to satisfy. Contributions welcome!
 
 ## Further Reading
 
@@ -178,7 +196,7 @@ to contribute any platform-specific providers you come up with!
 + [Documentation](docs/Documentation.md)
 + [Performance](docs/Performance.md)
 + [Migrating from v7 to v8](docs/MigrationV7toV8.md)
-+ [Roadmap](docs/Roadmap.md)
++ [Roadmap](roadmap.md)
 + [Releases and Release Notes](docs/Releases.md)
 + [Contributing](docs/Contributing.md)
 + [License](LICENSE)

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -13,8 +13,23 @@ Platform-specific implementation documentation can be found here:
 There are intended to be two main mechanisms for specifying which fields are to be included in a query response:
 1. A query string appended to the url, 'include'.
 2. A custom header attached to the request, 'POPCORN-INCLUDE'
- 
-Currently only the query string mechanism is actually supported in any provider.
+
+Currently only the query string mechanism is supported in the .NET provider. Header-based
+transport is on the roadmap — see [roadmap.md](../roadmap.md).
+
+### Names are wire names, not C# names
+
+This is protocol-level, and it matters for any client: the names in an `?include=` list are
+matched against the **wire name** of each field — the name the client actually sees in
+response bodies. In the .NET provider this is whichever comes first:
+
+1. The value of `[JsonPropertyName("...")]` on the property, if present.
+2. The C# property name, normalized by any `JsonNamingPolicy` the server has configured
+   (CamelCase, SnakeCase, etc.).
+
+A client that sees `{"display_name": "..."}` in responses should request that field as
+`?include=[display_name]`. Requesting `?include=[DisplayName]` is silently treated as an
+unknown name and the field will not be emitted. Same rule applies to negation.
 
 <a name="includingFields"/>
 
@@ -79,6 +94,26 @@ Each entity type shall define its own default fields.  These are the implicit fi
 + No includes are specified at all
 + An empty set of includes are provided (ie, ```[]```)
 + The entity is included via a field reference in a parent object, but no subentity field list is provided or an empty list is provided. (Eg, ```[AllMyChildren]``` or ```[AllMyChildren[]]```)
+
+### Wildcards and negation
+
+Two keywords (both prefixed with `!`) let a client refer to the default and full field sets:
+
++ `!all` includes every available field on the target type.
++ `!default` is the default field set explicitly invoked — useful when combining with negation or an additional include.
+
+A `-` prefix on a field name negates it (removes it from what would otherwise be emitted):
+
+```
+?include=[!all,-Secret]      # everything except Secret
+?include=[!default,-Email]   # default set minus Email
+?include=[Id,Name,Child[Id,-Secret]]  # explicit plus nested with negation
+```
+
+Implementation contract: fields tagged with an "always emit" attribute (e.g. `[Always]` in the
+.NET provider) are emitted even under negation — negating an always-emit field is a silent
+no-op. Conversely, fields tagged "never emit" (e.g. `[Never]`) are never emitted, even if
+explicitly requested or covered by `!all`.
 
 <a name="methods"/>
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,37 +2,14 @@
 
 [Table Of Contents](TableOfContents.md)
 
-A high level overview of features we would like to develop, in relative priority order.
+The active roadmap now lives at the repo root: **[roadmap.md](../roadmap.md)**.
 
-1. Source Generator and AOT Compilation
-   - Optimize compile-time type checking and code generation
-   - Enhance error reporting and diagnostics
-   - Support for more complex type scenarios
-   - Performance profiling and optimization tools
+That file is kept in sync with the current development branch and covers:
 
-2. Documentation and Tooling
-   - Source generator documentation and examples
-   - Migration guides from runtime to compile-time
-   - Visual Studio/VS Code integration
-   - Debugging tools for generated code
+- Merge-to-master gates for v8 (source-generator line).
+- Shipped vs remaining v8 features.
+- Known deferred-quality items and remaining performance levers.
+- Open questions (header-based include transport, cross-language providers).
 
-3. Performance Optimizations
-   - Memory allocation reduction
-   - Startup time improvements
-   - Runtime performance metrics
-   - Benchmarking tools
-
-4. Core Features
-   - Enhanced schema generation
-   - Improved error handling
-   - Pagination support
-   - Filtering capabilities
-   - Calculated properties (Count, Max, Sum)
-
-5. Future Considerations
-   - GraphQL-style nested queries
-   - Real-time data support
-   - Custom expansion rules
-   - Integration with popular frameworks
-
-Feel free to check out how to [contribute](Contributing.md) towards these features!
+If you're looking at this page from a forked copy, bookmark [roadmap.md](../roadmap.md) instead —
+we won't be updating this page going forward.

--- a/docs/TableOfContents.md
+++ b/docs/TableOfContents.md
@@ -3,7 +3,7 @@
 
 + ### [Quick Start](QuickStart.md)
 
-+ ### [General Usage](Documentation.md)
++ ### [Protocol / General Usage](Documentation.md)
   + #### [Declaring Included Fields](Documentation.md#includedFields)
   + #### [Including Fields](Documentation.md#includingFields)
   + #### [Including Sub-Entities](Documentation.md#includingSubEntities)
@@ -11,33 +11,40 @@
   + #### [Default Fields](Documentation.md#defaultFields)
   + #### [Methods](Documentation.md#methods)
   + #### [Moving Forward](Documentation.md#movingForward)
-    
-+ ### [DotNet](dotnet/DotNetDocumentation.md)
+
++ ### [.NET implementation](dotnet/DotNetDocumentation.md)
+  + #### [Quick Start](dotnet/DotNetQuickStart.md)
   + #### [Getting Started](dotnet/DotNetTutorialGettingStarted.md)
+  + #### [Include Parameter Syntax](dotnet/DotNetTutorialIncludeParameterSyntax.md)
   + #### [Wildcard Includes](dotnet/DotNetTutorialWildcardIncludes.md)
-  + #### [Advanced Projections](dotnet/DotNetTutorialAdvancedProjections.md)
-    + ##### [Factories](dotnet/DotNetTutorialAdvancedProjections.md#factories)
-  + #### [Contexts](dotnet/DotNetTutorialContexts.md)
   + #### [Default Includes](dotnet/DotNetTutorialDefaultIncludes.md)
-  + #### [Expand From](dotnet/DotNetTutorialExpandFrom.md)
-  + #### [Sorting](dotnet/DotNetTutorialSorting.md)
-    + ##### ["Sort" parameter](dotnet/DotNetTutorialSorting.md#sort)
-    + ##### ["Sort Direction" parameter](dotnet/DotNetTutorialSorting.md#sortDirection)
-  + #### Lazy Loading
-  + #### [Authorizers](dotnet/DotNetTutorialAuthorizers.md)
-  + #### [Internal Only](dotnet/DotNetTutorialInternalOnly)
-  + #### [Inspectors](dotnet/DotNetTutorialInspectors.md)
-  
+  + #### [Internal-Only Fields (`[Never]`)](dotnet/DotNetTutorialInternalOnly.md)
+  + #### [Computed Fields & Factories](dotnet/DotNetTutorialAdvancedProjections.md)
+  + #### [Lazy Loading](dotnet/DotNetTutorialLazyLoading.md)
+
 + ### [Performance](Performance.md)
 
 + ### [Migrating from v7 to v8](MigrationV7toV8.md)
 
-+ ### [Roadmap](Roadmap.md)
++ ### [Roadmap](../roadmap.md)
 
 + ### [Releases and Release Notes](Releases.md)
 
 + ### [Contributing](Contributing.md)
 
 + ### <a href="https://github.com/SkywardApps/popcorn/blob/master/LICENSE">License</a>
-  
+
 + ### [Meet the Maintainers](Maintainers.md)
+
+## v7-only tutorials (legacy reflection engine)
+
+These describe features that exist only in the v7 runtime-reflection line (`Skyward.Api.Popcorn`).
+They have been replaced in v8 by patterns native to ASP.NET Core + System.Text.Json. The
+[migration guide](MigrationV7toV8.md) documents the v8 equivalent for each.
+
++ [Authorizers](dotnet/DotNetTutorialAuthorizers.md) — v8: ASP.NET Core authorization middleware.
++ [Sorting](dotnet/DotNetTutorialSorting.md) — v8: endpoint-layer sort, not a framework feature.
++ [Inspectors](dotnet/DotNetTutorialInspectors.md) — v8: `[PopcornEnvelope]` type + `UsePopcornExceptionHandler`.
++ [Contexts](dotnet/DotNetTutorialContexts.md) — v8: ASP.NET Core DI.
++ [Expand From](dotnet/DotNetTutorialExpandFrom.md) — v8: `[Never]` on source + hand factory, or Mapster.
++ [Blind Expansion](dotnet/DotNetTutorialBlindExpansion.md) — v8: standard `JsonConverter<T>`.

--- a/docs/dotnet/DotNetDocumentation.md
+++ b/docs/dotnet/DotNetDocumentation.md
@@ -2,20 +2,45 @@
 
 [Table Of Contents](../../docs/TableOfContents.md)
 
-Tutorials:
-+ [Getting Started](DotNetTutorialGettingStarted.md)
-+ [Include Parameter Syntax](DotNetTutorialIncludeParameterSyntax.md)
-+ [Wildcard Includes](DotNetTutorialWildcardIncludes.md)
-+ [Advanced Projections](DotNetTutorialAdvancedProjections.md)
-+ [Default Includes](DotNetTutorialDefaultIncludes.md)
-+ [Expand From Attribute](DotNetTutorialExpandFrom.md)
-+ [Sorting](DotNetTutorialSorting.md)
-+ [Internal Only Attrribute](DotNetTutorialInternalOnly.md)
-+ [Lazy Loading](DotNetTutorialLazyLoading.md)
-+ [Authorizers](DotNetTutorialAuthorizers.md)
-+ [Inspectors](DotNetTutorialInspectors.md)
-+ [Contexts](DotNetTutorialContexts)
+Popcorn's .NET provider ships as two NuGet packages:
 
-Implementation Details:
-+ OutputFormatter
-+ Expander
+- `Skyward.Api.Popcorn.SourceGen.Shared` — runtime attributes (`[Default]` / `[Always]` / `[Never]`
+  / `[SubPropertyDefault]`), envelopes (`ApiResponse<T>`, `Pop<T>`, `ApiError`), DI helpers,
+  exception middleware.
+- `Skyward.Api.Popcorn.SourceGen` — Roslyn source generator (analyzer-only, no runtime DLL).
+
+Both target .NET 8+ and are compatible with `PublishAot=True` and `PublishTrimmed=True`. Current
+version: `8.0.0-preview.1` (see [Releases](../Releases.md)).
+
+> **Coming from v7?** The v7 packages (`Skyward.Api.Popcorn` and `Skyward.Api.Popcorn.DotNetCore`)
+> are the runtime-reflection line — still on NuGet, still maintained, but cannot AOT-publish.
+> See [Migrating from v7 to v8](../MigrationV7toV8.md) for the upgrade path.
+
+## Tutorials (v8)
+
++ [Quick Start](DotNetQuickStart.md) — install the packages, wire up DI, make your first request.
++ [Getting Started](DotNetTutorialGettingStarted.md) — full walkthrough of a minimal API, models, and include queries.
++ [Include Parameter Syntax](DotNetTutorialIncludeParameterSyntax.md) — the `?include=[...]` grammar in detail.
++ [Wildcard Includes](DotNetTutorialWildcardIncludes.md) — `!all` / `!default` / negation.
++ [Default Includes](DotNetTutorialDefaultIncludes.md) — `[Default]` / `[Always]` / `[SubPropertyDefault]`.
++ [Internal-Only Fields](DotNetTutorialInternalOnly.md) — `[Never]` for fields that must not leave the server.
++ [Computed Fields](DotNetTutorialAdvancedProjections.md) — calculated properties and endpoint-side resolution.
++ [Lazy Loading](DotNetTutorialLazyLoading.md) — why v8 supports lazy loading by construction.
+
+## v7-only tutorials (reflection line)
+
+Tutorials for v7 features that do not exist in v8 — each carries a deprecation banner pointing
+at the v8 replacement. Listed for v7 users still on the runtime-reflection line:
+
++ [Authorizers](DotNetTutorialAuthorizers.md) → ASP.NET Core authorization middleware in v8.
++ [Sorting](DotNetTutorialSorting.md) → endpoint-layer sort in v8.
++ [Inspectors](DotNetTutorialInspectors.md) → `[PopcornEnvelope]` + `UsePopcornExceptionHandler` in v8.
++ [Contexts](DotNetTutorialContexts.md) → ASP.NET Core DI in v8.
++ [Expand From](DotNetTutorialExpandFrom.md) → `[Never]` / hand factory / Mapster in v8.
++ [Blind Expansion](DotNetTutorialBlindExpansion.md) → automatic in v8 for own types; `JsonConverter<T>` for external types.
+
+## Example projects
+
++ [`dotnet/PopcornAotExample/`](../../dotnet/PopcornAotExample/) — minimal API published with
+  `PublishAot=True` + `PublishTrimmed=True`. Exercises the `[PopcornEnvelope]` + exception middleware path.
++ [`dotnet/Examples/PopcornNet5Example/`](../../dotnet/Examples/PopcornNet5Example/) — legacy v7 example (scheduled for refresh or removal).

--- a/docs/dotnet/DotNetQuickStart.md
+++ b/docs/dotnet/DotNetQuickStart.md
@@ -2,19 +2,92 @@
 
 [Table Of Contents](../../docs/TableOfContents.md)
 
-There are two methods to get the code into your solution:
-1. Check out the project from [GitHub](https://github.com/SkywardApps/popcorn).  Add the PopcornNetStandard and PopcornNetStandard.WebApiCore projects to your solution, and add references to them as needed.
-2. (Preferred) Nuget! Open up your package manager console and type in ``` Install-Package Skyward.Api.Popcorn ``` and repeat for the Skyward.Api.Popcorn.WebApiCore package and others as desired.
+Drop Popcorn v8 into a minimal-API app in five minutes. For a full walkthrough (models, test
+data, multiple endpoints) see [Getting Started](DotNetTutorialGettingStarted.md).
 
-Now that the project is available, you can quickly get up and running by configuring the MvcOptions in your UseMvc call.
+> **v7 vs v8.** This is the v8 (source-generator) path — it works under `PublishAot=True` and
+> `PublishTrimmed=True`. If you're on the v7 `Skyward.Api.Popcorn` / `.DotNetCore` packages and
+> aren't ready to migrate, the v7 quick start is in the [migration guide](../MigrationV7toV8.md).
+
+## 1. Install the packages
+
+```xml
+<PackageReference Include="Skyward.Api.Popcorn.SourceGen.Shared" Version="8.0.0-preview.1" />
+<PackageReference Include="Skyward.Api.Popcorn.SourceGen"        Version="8.0.0-preview.1" PrivateAssets="all" />
+```
+
+`SourceGen` is marked `developmentDependency` — it only contributes the Roslyn analyzer, never a
+runtime DLL. `SourceGen.Shared` is the runtime library that carries attributes, envelopes, and
+middleware.
+
+## 2. Declare a `JsonSerializerContext`
+
+Popcorn's generator discovers types through standard `System.Text.Json`
+`[JsonSerializable]` attributes. Register each top-level response type — the generator walks
+nested types automatically.
 
 ```csharp
-	services.AddMvc((mvcOptions) =>
-	{
-		mvcOptions.UsePopcorn((popcornConfig) => {
-			popcornConfig
-				.Map<*SourceType*, *DestinationType*>()
-				*...Repeat...*;
-		});
-	});
+using System.Text.Json.Serialization;
+using Popcorn.Shared;
+
+[JsonSerializable(typeof(ApiResponse<List<Car>>))]
+[JsonSerializable(typeof(ApiResponse<Car>))]
+internal partial class AppJsonSerializerContext : JsonSerializerContext { }
 ```
+
+## 3. Wire up `Program.cs`
+
+```csharp
+using System.Text.Json;
+using Popcorn.Shared;
+
+var builder = WebApplication.CreateSlimBuilder(args);
+
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddPopcorn();
+
+builder.Services.ConfigureHttpJsonOptions(o =>
+{
+    o.SerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonSerializerContext.Default);
+    o.SerializerOptions.AddPopcornOptions(); // installs generator-emitted converters
+});
+
+var app = builder.Build();
+app.UsePopcornExceptionHandler(); // unhandled exceptions → ApiError envelope
+
+app.MapGet("/cars", (IPopcornAccessor access) =>
+    access.CreateResponse(new List<Car>
+    {
+        new(1, "Pontiac", "Firebird", 1981),
+        new(2, "Porsche", "Cayman",    2005),
+    }));
+
+app.Run();
+
+public record Car(int Id, string Make, string Model, int Year);
+```
+
+`CreateSlimBuilder` is the AOT-friendly host builder; if you don't plan to publish as AOT you
+can use `WebApplication.CreateBuilder(args)` instead.
+
+## 4. Make a request
+
+```
+GET /cars
+→ { "Success": true, "Data": [{ "Id":1, "Make":"Pontiac", "Model":"Firebird", "Year":1981 }, ...] }
+
+GET /cars?include=[Make,Model]
+→ { "Success": true, "Data": [{ "Make":"Pontiac", "Model":"Firebird" }, ...] }
+```
+
+## Where to go next
+
+- [Getting Started](DotNetTutorialGettingStarted.md) for a fuller walkthrough with multiple
+  models, default-include attributes, and nested sub-entity queries.
+- [Include Parameter Syntax](DotNetTutorialIncludeParameterSyntax.md) for the full `?include=`
+  grammar (negation, wildcards, nesting).
+- [Default Includes](DotNetTutorialDefaultIncludes.md) for `[Default]` / `[Always]` /
+  `[SubPropertyDefault]` attribute usage.
+- [Performance](../Performance.md) for benchmarked ratios vs raw `System.Text.Json` and v7.
+- [`dotnet/PopcornAotExample/`](../../dotnet/PopcornAotExample/) for a reference project that
+  publishes with `PublishAot=True` + `PublishTrimmed=True`.

--- a/docs/dotnet/DotNetTutorialAdvancedProjections.md
+++ b/docs/dotnet/DotNetTutorialAdvancedProjections.md
@@ -1,238 +1,124 @@
-# [Popcorn](../../README.md) > [Documentation](../Documentation.md) > [DotNet](DotNetDocumentation.md) > Tutorial: Advanced Projections
+# [Popcorn](../../README.md) > [Documentation](../Documentation.md) > [DotNet](DotNetDocumentation.md) > Tutorial: Computed Fields
 
-[Table Of Contents](../TableOfContents.md)
+[Table Of Contents](../../docs/TableOfContents.md)
 
-By now you've learned how to 'project' a data entity into another type, allowing you to filter out any properties that your api consumer didn't want.
-If that process is unclear, we recommend that you complete [Getting Started](DotNetTutorialGettingStarted.md) first.
+If you're new to Popcorn, start with [Getting Started](DotNetTutorialGettingStarted.md) first.
 
+Often an API wants to expose a value that isn't a database column — a full name derived from
+first and last, a formatted birthday, a sum of line items. In Popcorn v8 this is simply a
+**C# computed property**. There is no Popcorn-specific configuration; the generator picks up
+the property and treats it like any other.
 
-Next we'll explore some of the other options that using a projection exposes.  We will start out with something simple; attaching a new property.  
-We'll add it to the class EmployeeProjection:
+> **v7 → v8 note.** v7 shipped a `.Translate<T>(...)` configuration lambda for this job,
+> which could optionally close over ambient data via `SetContext(Dictionary<string, object>)`.
+> v8 drops both. Pure transforms become computed properties; anything that needs injected
+> services is resolved at the endpoint layer. See
+> [MigrationV7toV8.md §5](../MigrationV7toV8.md#5-translators-computed-fields).
+
+## Pattern 1: Pure transforms — C# computed properties
+
+This is almost all the "translator" cases you'll see in practice.
 
 ```csharp
-public string FullName { get; set; }
-```
-
-Our 'FullName' with be FirstName and LastName concatenated together with a space in between.  To incorporate this, we need to add a 'Translation'.
-A translation is a custom unit of code you can add to convert the source object into a property on the destination projection.  It can translate an
-existing property on the source, aggreate or combine multiple properties, or create data that doesn't exist at all on the source object.
-
-Let's put a translation into the configuration object to demonstrate:
-
-```csharp
-mvcOptions.UsePopcorn((popcornConfig) => {
-    popcornConfig
-        .Map<Employee, EmployeeProjection>(config: (employeeConfig) => {
-            employeeConfig.Translate(ep => ep.FullName, (e) => e.FirstName + " " + e.LastName);
-        })
-        .Map<Car, CarProjection>(defaultIncludes: "[Model,Make,Year]");
-});
-```
-
-Now use the Employee API endpoint, and you should get something like:
-
-```javascript
-http://localhost:50353/api/example/employees?include=[FirstName,LastName,FullName,Birthday]
-
+public class Employee
 {
-    "FirstName": "Liz",
-    "LastName": "Lemon",
-    "FullName": "Liz Lemon",
-    "Birthday": "19810501T00:00:00 GMT"
-},
-...
+    [Default] public string FirstName { get; set; } = "";
+    [Default] public string LastName  { get; set; } = "";
 
-```
+    public string FullName => $"{FirstName} {LastName}";
 
-Suddenly the client no longer has to figure out the employee's full name on their own! 
-
-The above example is probably better represented as a calculated property on the projection itself:
-
-```csharp
-public string FullName { get { return this.FirstName + " " + this.LastName; }
-```
-
-Which would have resulted in exactly the same output, but is a bit easier to maintain. 
-
-### Situation 1: Altering incoming data
-
-Our 'Birthday' output format is a standard ISO datetime, which includes a time.  Time doesn't really make sense to track for a birthday, so we'll update the generated output to display *only* the day/month/year part by changing the projection's property to a
-string type, and adding a translation to convert:
-
-```csharp
-public string Birthday { get; set; }
-```
-
-```csharp
-mvcOptions.UsePopcorn((popcornConfig) => {
-    popcornConfig
-        .Map<Employee, EmployeeProjection>(config: (employeeConfig) => {
-            employeeConfig
-                .Translate(ep => ep.FullName, (e) => e.FirstName + " " + e.LastName)
-                .Translate(ep => ep.Birthday, (e) => e.Birthday.ToString("MM/dd/yyyy"));
-        })
-        .Map<Car, CarProjection>(defaultIncludes: "[Model,Make,Year]");
-});
-```
-
-Spin up that same endpoint and witness the transformation our data has undergone:
-
-```javascript
-http://localhost:50353/api/example/employees?include=[FirstName,LastName,FullName,Birthday]
-
-{
-    "FirstName": "Liz",
-    "LastName": "Lemon",
-    "FullName": "Liz Lemon",
-    "Birthday": "05/01/1981"
-},
-...
-```
-
-### Situation 2: Integrating data external to the source object
-
-Sometimes we want to add information to a projection that simply wasn't contained in the source object.  In order to get access to the additional
-information, Popcorn has a concept of a 'context' -- that is, a Dictionary<string,object> -- that can be passed into your custom translations.  
-Your translations can use this entry point to access whatever they want outside of the source object.
-
-We can demonstrate this by adding an 'Owner' property to the CarProjection.  This owner will reference the Employee whose 'vehicles' list contains this
-car.  The car entity itself has no knowledge of this, so we'll have to iterate over each employee to figure the relationship out.
-
-```csharp
-public EmployeeProjection Owner { get; set; }
-```
-
-```csharp
-mvcOptions.UsePopcorn((popcornConfig) => {
-    popcornConfig
-        .Map<Employee, EmployeeProjection>(config: (employeeConfig) => {
-            // For employees we will determine a full name and reformat the date to include only the day portion.
-            employeeConfig
-                .Translate(ep => ep.FullName, (e) => e.FirstName + " " + e.LastName)
-                .Translate(ep => ep.Birthday, (e) => e.Birthday.ToString("MM/dd/yyyy"));
-        })
-        .Map<Car, CarProjection>(defaultIncludes: "[Model,Make,Year]", config: (carConfig) => {
-            // For cars we will query to find out the Employee who owns the car.
-            carConfig.Translate(cp => cp.Owner, (car, context) => 
-                // The car parameter is the source object; the context parameter is the dictionary we configure below.
-                (context["database"] as ExampleContext).Employees.FirstOrDefault(e => e.Vehicles.Contains(car)));
-        })
-        // Pass in our 'database' via the context
-        .SetContext(new Dictionary<string, object> {
-            ["database"] = database
-        });
-});
-```
-
-Now if we request the Owner property, we'll get the details of the employee too!
-
-```javascript
-http://localhost:50353/api/example/cars?include=[Model,Make,Year,Color,Owner[FullName]]
-
-[
-    {
-        "Owner": {
-            "FullName": "Liz Lemon"
-        },
-        "Model": "Firebird",
-        "Make": "Pontiac",
-        "Year": 1981,
-        "Color": "Blue"
-    },
-    {
-        "Owner": {
-            "FullName": "Jack Donaghy"
-        },
-        "Model": "250 GTO",
-        "Make": "Ferrari N.V.",
-        "Year": 1962,
-        "Color": "Red"
-    },
-    {
-        "Owner": {
-            "FullName": "Jack Donaghy"
-        },
-        "Model": "Cayman",
-        "Make": "Porsche",
-        "Year": 2005,
-        "Color": "Yellow"
-    }
-]
-```
-## Factories<a name="factories"/>
-With Factories it's possible to extract the projection class instantiation. You can either use a plain factory or one that takes a context object as an input parameter. The big advantage of using a context object is that the instantiation can be configured to its needs.
-
-In the following example the Employee model consists of a property that describes the employment type (eg. FullTime/PartTime). If this employment type is not explicitly requested, using the include parameter or by requesting the entire model, it depends on its initial value. With a context-based factory, this value can be set according to the current configuration.
-
-```csharp
-public enum EmploymentType
-{
-    Employed,
-    PartTime,
-    FullTime
+    public DateTimeOffset Birthday { get; set; }
+    public string BirthdayShort => Birthday.ToString("yyyy-MM-dd");
 }
 ```
 
-```csharp
-public class EmployeeProjection
+```
+GET /employees?include=[FullName,BirthdayShort]
+```
+
+```json
 {
-	...
-	public EmploymentType Employment { get;set; }
+  "Success": true,
+  "Data": [
+    { "FullName": "Liz Lemon",   "BirthdayShort": "1981-05-01" },
+    { "FullName": "Jack Donaghy", "BirthdayShort": "1957-07-12" }
+  ]
 }
 ```
 
+The include list drives which computed properties run: if the client doesn't ask for
+`FullName`, the getter never executes. Same cost model as any other property.
+
+## Pattern 2: Needs injected services — resolve at the endpoint
+
+If the value depends on an injected service (a database, an external API, current-user
+state), compute it where the data lives — in the endpoint — before handing it to Popcorn:
+
 ```csharp
-popcornConfig
-    .Map<Employee, EmployeeProjection>()
-    .AssignFactory<EmployeeProjection>((context) => EmployeeFactory(context))
-    .SetContext(new Dictionary<string, object>
-    {
-        ["defaultEmployment"] = EmploymentType.Employed
-	});
+app.MapGet("/cars", (IPopcornAccessor access, IEmployeeLookup lookup, ExampleContext db) =>
+{
+    var ownerById = lookup.FindMany(db.Cars.Select(c => c.OwnerId).Distinct());
 
-...
-
-private EmployeeProjection EmployeeFactory(Dictionary<string, object> context)
+    var view = db.Cars.Select(c => new CarDto
     {
-        return new EmployeeProjection
-        {
-            Employment = context["defaultEmployment"] as EmploymentType?
-        };
-    }
+        Id    = c.Id,
+        Make  = c.Make,
+        Model = c.Model,
+        Owner = ownerById.GetValueOrDefault(c.OwnerId),   // one lookup, batched
+    }).ToList();
+
+    return access.CreateResponse(view);
+});
 ```
 
-According to this context configuration every EmployeeProjection object will be instantiated with a Employment value of `EmploymentType.Employed`.
-Requesting only FirstName and LastName will provide us with a default EmploymentType:
-```javascript
-http://localhost:35632/api/example/employees?include=[FirstName,LastName]
+Why this is the recommended pattern for DI-needing "translators":
 
-[
-    {
-        "FirstName": "Liz",
-        "LastName": "Lemon",
-        "Employment": "Employed"
-    },
-    {
-        "FirstName": "Jack",
-        "LastName": "Donaghy",
-        "Employment": "Employed"
-    }
-]
+- **Batchable.** One DB query for all owners, not one per car.
+- **Clear I/O boundaries.** Database access happens in the endpoint, not mid-serialization.
+- **Testable.** The endpoint is the unit; you don't need a running `JsonSerializerOptions` to
+  exercise the logic.
+- **Composable.** Your DTO is just a type. You can add `[Never]` / `[Default]` / `[Always]`
+  attributes on it exactly like any Popcorn-registered model.
+
+## Pattern 3: External types — standard `JsonConverter<T>`
+
+Sometimes a type comes from a library you don't control — `NetTopologySuite.Geometry` is the
+canonical example — and you want it rendered a particular way. Popcorn composes transparently
+with standard `System.Text.Json` converters. Register the converter once:
+
+```csharp
+public class GeometryConverter : JsonConverter<Geometry>
+{
+    public override void Write(Utf8JsonWriter writer, Geometry value, JsonSerializerOptions options)
+        => writer.WriteStringValue(value.ToText()); // WKT
+
+    public override Geometry Read(…) => throw new NotImplementedException();
+}
+
+builder.Services.ConfigureHttpJsonOptions(o =>
+{
+    o.SerializerOptions.Converters.Add(new GeometryConverter());
+    o.SerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonSerializerContext.Default);
+    o.SerializerOptions.AddPopcornOptions();
+});
 ```
 
-By including the Employment property in the request, you'll get the exact EmploymentTypes.
-```javascript
-http://localhost:35632/api/example/employees?include=[FirstName,LastName,Employment]
- [
-	{
-		"FirstName": "Liz",
-        "LastName": "Lemon",
-        "Employment": "FullTime"
-     },
-     {
-		"FirstName": "Jack",
-        "LastName": "Donaghy",
-        "Employment": "PartTime"
-     }
-]
-```
+When Popcorn's generator hits a `Geometry` property it doesn't know how to walk, it falls
+through to `JsonSerializer.Serialize(…, options)`, which picks up your registered converter.
+
+## Factories (deferred)
+
+v7 had `.AssignFactory<T>(ctx => …)` for controlling how projection instances are constructed.
+v8 doesn't need this for the write path — the generator never constructs your types, it just
+reads them. Factories become relevant again if deserialization ships in a future v8.x release.
+See [the roadmap](../../roadmap.md) for status.
+
+## See also
+
+- [Default Includes](DotNetTutorialDefaultIncludes.md) for shaping what a bare request returns.
+- [MigrationV7toV8.md §5](../MigrationV7toV8.md#5-translators-computed-fields) — full v7 → v8
+  mapping for translators.
+- [MigrationV7toV8.md §7](../MigrationV7toV8.md#7-projections-replacing-mapentityframework) —
+  projection replacement patterns.
+- [MigrationV7toV8.md §8](../MigrationV7toV8.md#8-external-type-handlers-blindhandler) —
+  `JsonConverter<T>` for external types.

--- a/docs/dotnet/DotNetTutorialAuthorizers.md
+++ b/docs/dotnet/DotNetTutorialAuthorizers.md
@@ -2,6 +2,18 @@
 
 [Table Of Contents](../../docs/TableOfContents.md)
 
+> ⚠️ **v7-only — dropped in v8.** The `.Authorize<T>(...)` lambda configuration does not exist
+> in v8. Authorization decisions belong at the endpoint / policy layer, not inside the
+> serializer. Use:
+>
+> - **ASP.NET Core `[Authorize]` attributes / policies** to gate whole endpoints.
+> - **Endpoint-level checks** (`if (!userCanSee(car)) return Forbid();`) when per-row filtering is needed.
+> - **`[Never]` on sensitive properties** to hard-exclude fields from the API shape regardless of caller.
+>
+> Full rationale: [MigrationV7toV8.md §9](../MigrationV7toV8.md#9-dropped-from-v8-these-will-not-return).
+>
+> The tutorial below is preserved for v7 users still on that line.
+
 Restricting access to information in our APIs is so important and can often be incredibly complex. We recognize this inevitable struggle
 and are now offering an "Authorize" setting within your Popcorn configuration to restrict responses as you see fit 
 and hopefully mitigate part of that trouble.

--- a/docs/dotnet/DotNetTutorialBlindExpansion.md
+++ b/docs/dotnet/DotNetTutorialBlindExpansion.md
@@ -1,5 +1,20 @@
 # [Popcorn](../../README.md) > [Documentation](../Documentation.md) > [DotNet](DotNetDocumentation.md) > Tutorial: Blind Expansion
 
+> ⚠️ **v7-only — dropped in v8.** `EnableBlindExpansion(true)` and the `BlindHandler<TFrom, TTo>`
+> registration no longer exist. Two clean v8 answers cover what this feature did:
+>
+> - **For your own types:** v8 walks your type graph automatically. Add
+>   `[JsonSerializable(typeof(ApiResponse<Business>))]` to your `JsonSerializerContext`, and the
+>   generator emits a converter for every reachable type. No extra "turn on blind expansion" flag.
+> - **For external types** (e.g. `NetTopologySuite.Geometry`): register a standard
+>   `JsonConverter<Geometry>` on `JsonSerializerOptions.Converters`. Popcorn composes with STJ
+>   converters transparently — when Popcorn's generator hits a type it doesn't recognize, it
+>   falls through to `JsonSerializer.Serialize(…)`, which picks up your registered converter.
+>
+> Full rationale + code samples: [MigrationV7toV8.md §8](../MigrationV7toV8.md#8-external-type-handlers-blindhandler).
+>
+> The tutorial below is preserved for v7 users still on that line.
+
 We may not want to actually have to project out all of your objects and map them as that may not be a layer of abstraction 
 you or your team care to have. We recognize that while projections do offer another layer of protection and 
 more flexiblity within Popcorn, our users need to be able to quickly get started and get moving.

--- a/docs/dotnet/DotNetTutorialContexts.md
+++ b/docs/dotnet/DotNetTutorialContexts.md
@@ -1,5 +1,21 @@
 # [Popcorn](../../README.md) > [Documentation](../Documentation.md) > [DotNet](DotNetDocumentation.md) > Tutorial: Setting Contexts
 
+> ⚠️ **v7-only — dropped in v8.** `SetContext(Dictionary<string, object>)` does not exist in v8.
+> The entire "pass an ambient dictionary to your lambdas" pattern is superseded by standard
+> ASP.NET Core **dependency injection**:
+>
+> ```csharp
+> builder.Services.AddSingleton<ExampleContext>(database);
+>
+> app.MapGet("/cars", (IPopcornAccessor access, ExampleContext db) =>
+>     access.CreateResponse(db.Cars));
+> ```
+>
+> Translator lambdas that needed ambient data in v7 become endpoint-side resolution in v8 (see
+> [MigrationV7toV8.md §5](../MigrationV7toV8.md#5-translators-computed-fields)).
+>
+> The tutorial below is preserved for v7 users still on that line.
+
 Popcorn does not know about everything in your application on its own. Actually, it's aware of virtually nothing without being specifically told and thus 
 we use .NET MVC options with the Popcorn Configuration as an abstraction layer between whatever it is you're doing on your back end and your API.
 

--- a/docs/dotnet/DotNetTutorialDefaultIncludes.md
+++ b/docs/dotnet/DotNetTutorialDefaultIncludes.md
@@ -2,312 +2,201 @@
 
 [Table Of Contents](../../docs/TableOfContents.md)
 
-If you are unfamiliar with how to 'project' a data entity into another type please complete the [Getting Started](DotNetTutorialGettingStarted.md) first.
+If you're new to Popcorn, start with [Getting Started](DotNetTutorialGettingStarted.md) —
+this tutorial assumes you already have a working app and understand the basics of `?include=`.
 
-Popcorn's projections are very powerful, but you probably don't want to have to specify what should be included 
-in a response object every time.
+Popcorn lets you declare which fields show up when the client makes a "bare" request — one
+with no `?include=` parameter or with an empty `?include=[]`. You do this with three
+attributes on the model, all in the `Popcorn` namespace.
 
-This tutorial will walk you through the two ways you can declare default properties on your projections - while also discussing a way
-to include subproperties on an object by default.
+| Attribute | Emitted when |
+|---|---|
+| `[Always]` | Every response, regardless of `?include=`. Cannot be negated. |
+| `[Default]` | `?include=` is absent, empty, or `!default`. Can be negated via `-FieldName`. |
+| `[Never]`  | Never. Not even when `?include=[FieldName]` asks for it explicitly. |
 
-First let's start with an example!
-Let's look at our intial Employee object and its projection
+## Example model
+
+Suppose we extend the `Employee` model from [Getting Started](DotNetTutorialGettingStarted.md)
+with a computed `FullName` property:
+
 ```csharp
+using Popcorn;
+
 public class Employee
 {
-    public string FirstName { get; set; }
-    public string LastName { get; set; }
+    public string FirstName { get; set; } = "";
+    public string LastName  { get; set; } = "";
+    public string FullName => $"{FirstName} {LastName}";
 
     public DateTimeOffset Birthday { get; set; }
     public int VacationDays { get; set; }
 
-    public List<Car> Vehicles { get; set; }
+    public List<Car> Vehicles { get; set; } = new();
 }
 ```
+
+A bare `GET /employees` request would return every public property. For most APIs that's too
+much — the client ends up paying for data it won't render. Let's declare a smaller default.
+
+## Controlling the default set with `[Default]`
 
 ```csharp
-public class EmployeeProjection
+public class Employee
 {
-	public string FirstName { get; set; }
-	public string LastName { get; set; }
-	public string FullName { get; set; }
+    [Default] public string FirstName { get; set; } = "";
+    [Default] public string LastName  { get; set; } = "";
+    public string FullName => $"{FirstName} {LastName}";
 
-	public string Birthday { get; set; }
-	public int? VacationDays { get; set; }
+    public DateTimeOffset Birthday { get; set; }
+    public int VacationDays { get; set; }
 
-	public List<CarProjection> Vehicles { get; set; }
+    public List<Car> Vehicles { get; set; } = new();
 }
 ```
 
-Now, assuming you've mapped the projection as we've discussed in [Getting Started](DotNetTutorialGettingStarted.md) let's see what
-comes back from our "Employee" endpoint with no include statement
+```
+GET /employees
+```
 
-```javascript
-http://localhost:50353/api/example/employees
-
+```json
 {
-	"FirstName": "Liz",
-	"LastName": "Lemon",
-	"FullName": "Liz Lemon",
-	"Birthday": "05/01/1981",
-	"VacationDays": 0,
-	"Vehicles": [
-		{
-			"Model": "Firebird",
-			"Make": "Pontiac",
-			"Year": 1981
-		}
-	]
-},
-{
-	"FirstName": "Jack",
-	"LastName": "Donaghy",
-	"FullName": "Jack Donaghy",
-	"Birthday": "07/12/1957",
-	"VacationDays": 300,
-	"Vehicles": [
-		{
-			"Model": "250 GTO",
-			"Make": "Ferrari N.V.",
-			"Year": 1962
-		},
-		{
-			"Model": "Cayman",
-			"Make": "Porsche",
-			"Year": 2005
-		}
-	]
+  "Success": true,
+  "Data": [
+    { "FirstName": "Liz",  "LastName": "Lemon"   },
+    { "FirstName": "Jack", "LastName": "Donaghy" }
+  ]
 }
 ```
 
-That is a lot of information, but what if we know that the standard request for employees should only include the "FirstName" and "LastName" by default, as our database may be enormous and returning all information unnecessarily is time consuming.
+The `Birthday`, `VacationDays`, `FullName`, and `Vehicles` fields are still available on the
+wire — clients just have to ask for them:
 
-The answer is default properties.
+```
+GET /employees?include=[FirstName,Birthday,FullName]
+```
 
-### Option 1: Declaring default properties on the projection
+```json
+{
+  "Success": true,
+  "Data": [
+    { "FirstName": "Liz",  "Birthday": "1981-05-01T00:00:00+00:00", "FullName": "Liz Lemon"   },
+    { "FirstName": "Jack", "Birthday": "1957-07-12T00:00:00+00:00", "FullName": "Jack Donaghy" }
+  ]
+}
+```
 
-This is the recommended way to declare defaults as it is very easily maintained and makes it clear which defaults have been set.
-Plus, it blends seamlessly with the subproperty default include system.
+## The "no attributes" rule
 
+If a type has **no** `[Default]` or `[Always]` attributes anywhere, every property is treated
+as default-included. This keeps getting-started friction low — you can start emitting everything
+and only introduce attributes when you want to tighten the default set.
 
+| Attribute layout | Default set |
+|---|---|
+| No `[Default]` / `[Always]` anywhere on the type | All properties |
+| At least one `[Default]` | Only properties marked `[Default]` or `[Always]` |
+| `[Never]` on a property | That property is excluded, always, regardless of other rules |
 
-Go back to your Employee projection and add the property [IncludeByDefault] to "FirstName" and "LastName"
+Inheritance: `[Default]` / `[Always]` on a base class flow through to derived classes. `[Never]`
+does the same. You don't need to re-declare them on the subclass.
+
+## `[Always]` for fields that must be on every response
+
+Some fields — primary keys, tenant IDs, version columns — should always be present even if the
+client forgot to ask. `[Always]` guarantees that:
+
 ```csharp
-public class EmployeeProjection
+public class Employee
 {
-	[IncludeByDefault]
-	public string FirstName { get; set; }
-	[IncludeByDefault]
-	public string LastName { get; set; }
-	public string FullName { get; set; }
-
-	public string Birthday { get; set; }
-	public int? VacationDays { get; set; }
-
-	public List<CarProjection> Vehicles { get; set; }
+    [Always]  public int Id { get; set; }
+    [Default] public string FirstName { get; set; } = "";
+    [Default] public string LastName  { get; set; } = "";
+    ...
 }
 ```
 
-Now boot up the project and make the employees request again with no include statement.
-```javascript
-http://localhost:50353/api/example/employees
+```
+GET /employees?include=[FirstName]
+```
 
+```json
 {
-	"FirstName": "Liz",
-	"LastName": "Lemon"
-},
-{
-	"FirstName": "Jack",
-	"LastName": "Donaghy"
+  "Success": true,
+  "Data": [
+    { "Id": 1, "FirstName": "Liz"  },
+    { "Id": 2, "FirstName": "Jack" }
+  ]
 }
 ```
 
-Much more streamlined, and we can still send a request out with ?include=[...] and access
-all of the properties exposed on the projection, overriding the DefaultInclude statement.
+`Id` shows up even though the client didn't list it. Negation won't remove it either — a
+request for `?include=[!all,-Id]` still emits `Id`. If a field is genuinely sensitive, use
+`[Never]`, not `[Always]` — see [Internal-Only Fields](DotNetTutorialInternalOnly.md).
 
-*Important FYI: Derived classes will inherit their base class' [IncludeByDefault]'s by default and can be overridden 
-in the usual fashion with a specific ?include in a request.* 
+## Sub-property defaults via `[SubPropertyDefault]`
 
-### Option 2: Including a DefaultIncludes string at "Map" time
+When a property is a complex type (like `List<Car>`), including the parent without specifying
+sub-children normally falls back to the child type's own default set. `[SubPropertyDefault]`
+lets you override that decision *for this property*:
 
-You'll remember in our [Advanced Projections Tutorial](DotNetTutorialAdvancedProjections.md) we explained translations on the mappings.
-In addition to that functionality, you can also pass in a defaultIncludes string at the time of a mapping to include certain properties 
-by default.
-
-Let's shift to the Car object and projection and see how that is applied there
 ```csharp
-public class Car
+public class Employee
 {
-    public string Model { get; set; }
-    public string Make { get; set; }
-    public int Year { get; set; }
+    [Default] public string FirstName { get; set; } = "";
+    [Default] public string LastName  { get; set; } = "";
 
-    public enum Colors
+    [SubPropertyDefault("[Make,Model,Color]")]
+    public List<Car> Vehicles { get; set; } = new();
+}
+```
+
+```
+GET /employees?include=[FirstName,Vehicles]
+```
+
+```json
+{
+  "Success": true,
+  "Data": [
     {
-        Black,
-        Red,
-        Blue,
-        Gray,
-        White,
-        Yellow,
-    }
-    public Colors Color { get; set; }
-}
-
-```csharp
-public class CarProjection
-{
-	public string Model { get; set; }
-	public string Make { get; set; }
-	public int? Year { get; set; }
-	public string Color { get; set; }
+      "FirstName": "Liz",
+      "Vehicles": [
+        { "Make": "Pontiac", "Model": "Firebird", "Color": 2 }
+      ]
+    },
+    ...
+  ]
 }
 ```
 
-As you've seen above with the Employee Projection, with no default includes, making a request to the "cars" endpoint 
-will return all 4 exposed properties. Again, let us say we only care to see Make, Model, and Year by default on our returned objects.
+Without the attribute, `Vehicles` would have emitted the `Car` type's own default set. The
+override applies only when the client doesn't spell out sub-children: `?include=[Vehicles[Year]]`
+still wins (explicit sub-children beat the attribute), and `[Never]` on a `Car` property still
+wins over the attribute (declared "never-emit" always beats "default-emit").
 
-We return to our mapping statement in Startup.cs and configure it as seen below, ignoring the translation for clarity.
-```csharp
-mvcOptions.UsePopcorn((popcornConfig) => {
-	popcornConfig
-		.Map<Car, CarProjection>(defaultIncludes: "[Model,Make,Year]", config: (carConfig) => {
-			...
-		}
+The include string is parsed once per process into a static readonly field at generation time —
+no per-request parsing cost.
+
+## Negation and `!default` keyword
+
+`?include=[!default]` is shorthand for "the default set" — useful when you want the default
+set *plus* a couple of extra fields:
+
+```
+GET /employees?include=[!default,Birthday]
+→ default set (FirstName + LastName) plus Birthday
+
+GET /employees?include=[!default,-LastName]
+→ default set minus LastName (FirstName only)
 ```
 
-Now if we fired up our program again and made the "cars" request we would see a response like the below
-```javascript
-http://localhost:50353/api/example/employees
+`[Always]`-marked fields are still included regardless of negation — `-Id` is a silent no-op
+if `Id` is marked `[Always]`.
 
-{
-	"Model": "Firebird",
-	"Make": "Pontiac",
-	"Year": 1981
-},
-{
-	"Model": "250 GTO",
-	"Make": "Ferrari N.V.",
-	"Year": 1962
-},
-{
-	"Model": "Cayman",
-	"Make": "Porsche",
-	"Year": 2005
-}
-```
+## See also
 
-Voila! Default inclusion complete.
-
-## Important caveat
-It is important to mention that both option 1 and option 2 can't be used at the same time on any single projection in order to help maintain clarity of design.
-
-## Default Behavior When No Attributes Are Present
-
-Starting with version 2.0, Popcorn introduces a more intuitive default behavior:
-
-**If a type has no properties or fields with either `[Always]` or `[Default]` attributes, then all properties and fields of that type are considered Default.**
-
-This means:
-
-1. If you mark one or more properties with `[Default]` or `[Always]`, only those properties (and any with `[Always]`) will be included by default
-2. If you don't mark any properties with attributes, all properties will be included by default
-3. Properties marked with `[Never]` are still excluded, even when all other properties are included by default
-
-This behavior makes Popcorn more intuitive for new users while maintaining backward compatibility with existing code that uses attributes.
-
-### Examples:
-
-**Example 1: No attributes - all properties included by default**
-```csharp
-public class Person
-{
-    public int Id { get; set; }
-    public string Name { get; set; }
-    public int Age { get; set; }
-}
-```
-All properties (Id, Name, Age) will be included by default.
-
-**Example 2: One Default attribute - only that property included by default**
-```csharp
-public class Person
-{
-    [Default]
-    public int Id { get; set; }
-    public string Name { get; set; }
-    public int Age { get; set; }
-}
-```
-Only the Id property will be included by default.
-
-**Example 3: Never attribute with no other attributes - all properties except Never included by default**
-```csharp
-public class Person
-{
-    public int Id { get; set; }
-    public string Name { get; set; }
-    [Never]
-    public int Age { get; set; }
-}
-```
-Id and Name will be included by default, but Age will never be included.
-
-### Default includes on subproperties
-We've also created a "SubPropertyDefaultIncludes" property that can be put on a projection to have any subordinate object
-returned with a set of default properties.
-
-Things to remember:
-1. The SubPropertyDefaultIncludes will override any DefaultIncludes (be it mapped or a property) on the actual projection being referenced.
-2. Just like with DefaultIncludes, the sub-entities properties can still be included in the ?include=[..[..]] statement to override the SubPropertyDefaultIncludes.
-	
-Again, we return to EmployeeProjection to see this feature in use:
-```csharp
-public class EmployeeProjection
-{
-	[IncludeByDefault]
-	public string FirstName { get; set; }
-	[IncludeByDefault]
-	public string LastName { get; set; }
-	public string FullName { get; set; }
-
-	public string Birthday { get; set; }
-	public int? VacationDays { get; set; }
-
-	[SubPropertyIncludeByDefault("[Make,Model,Color]")]
-	public List<CarProjection> Vehicles { get; set; }
-}
-```
-
-You'll see that we added a "SubPropertyIncludeByDefault" to our Vehicles property that specifies a standard "include" format list of properties.
-As mentioned above, by default the "employees?include=[Vehicle]" request will return the Make, Model, and Year as that
-is the default set to the car projection.
-
-Now let's see what happens with the addition of the "SubPropertyIncludeByDefault" property.
-
-```javascript
-http://localhost:49695/api/example/employees?include=[Vehicles]
-{
-	"Vehicles": [
-		{
-			"Model": "Firebird",
-			"Make": "Pontiac",
-			"Color": "Blue"
-		}
-	]
-},
-{
-	"Vehicles": [
-		{
-			"Model": "250 GTO",
-			"Make": "Ferrari N.V.",
-			"Color": "Red"
-		},
-		{
-			"Model": "Cayman",
-			"Make": "Porsche",
-			"Color": "Yellow"
-		}
-	]
-}
-```
+- [Include Parameter Syntax](DotNetTutorialIncludeParameterSyntax.md) for the full grammar
+  (nesting, negation, `!all`).
+- [Internal-Only Fields](DotNetTutorialInternalOnly.md) for `[Never]`.
+- [Wildcard Includes](DotNetTutorialWildcardIncludes.md) for `!all`.

--- a/docs/dotnet/DotNetTutorialExpandFrom.md
+++ b/docs/dotnet/DotNetTutorialExpandFrom.md
@@ -2,6 +2,18 @@
 
 [Table Of Contents](../../docs/TableOfContents.md)
 
+> ⚠️ **v7-only — dropped in v8.** The `[ExpandFrom]` attribute and the projection-class pattern
+> it supports exist only in the v7 runtime-reflection line (`Skyward.Api.Popcorn` /
+> `.DotNetCore`). v8 does not ship it. The v8 replacements, in rough order of preference:
+>
+> 1. Decorate the source type directly with `[Never]` on internal properties (one source of truth, no projection class).
+> 2. Write a three-line hand factory (`public static CarDto From(CarEntity src) => new(...)`) when the domain/API boundary is hard.
+> 3. Use [Mapster.SourceGenerator](https://github.com/MapsterMapper/Mapster) for complex flattening — it is AOT-compatible and composes with Popcorn.
+>
+> Full rationale and code samples: [MigrationV7toV8.md §7](../MigrationV7toV8.md#7-projections-replacing-mapentityframework).
+>
+> The tutorial below is preserved for v7 users still on that line.
+
 The power of Popcorn comes in its ability to expand objects dynamically based on the specified object's properties.
 
 There are currently 3 ways that an object can be "Mapped" so it will be expanded by Popcorn. 

--- a/docs/dotnet/DotNetTutorialGettingStarted.md
+++ b/docs/dotnet/DotNetTutorialGettingStarted.md
@@ -2,343 +2,260 @@
 
 [Table Of Contents](../../docs/TableOfContents.md)
 
-Ok, so you want to jump in with both feet and get Popcorn set up and running.
-This tutorial will walk through a simple Asp.Net Core application demonstrating the basic functionality.
+This walkthrough builds a minimal ASP.NET Core web API with Popcorn v8 end-to-end: models,
+endpoints, and include-aware responses. If you already have an app and just need the wire-up
+steps, see the short [Quick Start](DotNetQuickStart.md) instead.
 
-All source code is available in the 'PopcornNetCoreExample' project in the dotnet solution.
+> **A brief note on the two Popcorn versions.** Popcorn v1 through v7 (on NuGet as
+> `Skyward.Api.Popcorn` and `.DotNetCore`) used **runtime reflection** to walk response
+> objects and filter fields. That approach is incompatible with .NET's AOT compilation and IL
+> trimming — two deployment features that are increasingly common in newer .NET stacks.
+>
+> **Popcorn v8** (this tutorial) is a rewrite on top of a **Roslyn source generator**. At build
+> time the generator reads your `[JsonSerializable(typeof(ApiResponse<T>))]` declarations,
+> walks the type graph, and emits a straight-line `JsonConverter<T>` per reachable type — no
+> reflection at runtime, no metadata the trimmer can strip. The URL grammar, attribute
+> semantics, and response envelope shape are unchanged; only the internals and extension-point
+> API moved.
+>
+> Coming from v7? See the [v7 → v8 migration guide](../MigrationV7toV8.md) — most of the
+> changes are find-and-replace.
 
-To get us started off, create a brand new 'Asp.Net Core' project.
+## 1. Create a new ASP.NET Core project
 
-![Project Type](QS.01.ProjectType.png)
-
-Make sure to choose 'Web Api' as your project type to get the appropriate templates in place.
-
-![Project Type](QS.02.ProjectSettings.png)
-
-You should now have a 'Program.cs' file that sets up the hosting environment,
-and a 'Startup.cs' configuring the Web Api.
-
-There's also a ValueController by default.  We don't need it, so go ahead and delete it.
-Instead, lets create an 'ExampleController' with just one endpoint for now.
-
-```csharp
-using System.Collections.Generic;
-using Microsoft.AspNetCore.Mvc;
-
-namespace PopcornNetCoreExample.Controllers
-{
-    [Route("api/example/")]
-    public class ExampleController : Controller
-    {
-        [HttpGet, Route("status")]
-        public string Status()
-        {
-            return "OK";
-        }
-    }
-}
+```bash
+dotnet new web -n PopcornDemo
+cd PopcornDemo
 ```
 
-Now, let's make sure our basic app is up and running.
-We will be using [Postman](https://www.getpostman.com/) to test our controller.
-Fire it up, start your Web Api project, and execute a 'GET' request against your new endpoint '/api/example/status'
-![Project Type](QS.03.PostmanStatus.png)
+We'll use minimal APIs — they compose cleanly with AOT publishing and reduce boilerplate. If
+you prefer controllers, the same setup applies; `IPopcornAccessor` is injected the same way.
 
+## 2. Install the Popcorn packages
 
-Now we can start to introduce some Popcorn!
+```bash
+dotnet add package Skyward.Api.Popcorn.SourceGen.Shared --version 8.0.0-preview.1
+dotnet add package Skyward.Api.Popcorn.SourceGen        --version 8.0.0-preview.1
+```
 
-To get started, create a 'Models' subfolder in your project, and add two classes: Employee and Car.
+The csproj will look like:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Skyward.Api.Popcorn.SourceGen.Shared" Version="8.0.0-preview.1" />
+  <PackageReference Include="Skyward.Api.Popcorn.SourceGen"        Version="8.0.0-preview.1" PrivateAssets="all" />
+</ItemGroup>
+```
+
+`SourceGen` is marked `developmentDependency` — it only contributes the Roslyn analyzer, never
+a runtime DLL. `SourceGen.Shared` carries the attributes, envelopes, and middleware.
+
+## 3. Define your models
+
+Create a `Models` folder and add `Employee.cs` and `Car.cs`:
 
 ```csharp
+namespace PopcornDemo.Models;
+
 public class Employee
 {
-    public string FirstName { get; set; }
-    public string LastName { get; set; }
+    public string FirstName { get; set; } = "";
+    public string LastName  { get; set; } = "";
 
     public DateTimeOffset Birthday { get; set; }
     public int VacationDays { get; set; }
 
-    public List<Car> Vehicles { get; set; }
+    public List<Car> Vehicles { get; set; } = new();
 }
-```
 
-```csharp
 public class Car
 {
-    public string Model { get; set; }
-    public string Make { get; set; }
+    public string Make  { get; set; } = "";
+    public string Model { get; set; } = "";
     public int Year { get; set; }
-    
-    public enum Colors
-    {
-        Black,
-        Red,
-        Blue,
-        Gray,
-        White,
-        Yellow,
-    }
+
     public Colors Color { get; set; }
 }
+
+public enum Colors { Black, Red, Blue, Gray, White, Yellow }
 ```
 
-These are the entities we'll be querying for via the API.
+Unlike v7, there is no separate "projection class" step — Popcorn serializes your model
+directly. You control what's exposed through attributes on the model itself (next step).
 
-Lets add an 'ExampleContext' class that will act as an in-memory repository for our test data.
+## 4. Add some test data
+
+Add `ExampleContext.cs` in the same folder:
+
 ```csharp
+namespace PopcornDemo.Models;
+
 public class ExampleContext
 {
-    public List<Car> Cars { get; } = new List<Car>();
-    public List<Employee> Employees { get; } = new List<Employee>();
-}
-```
+    public List<Employee> Employees { get; }
+    public List<Car>      Cars      { get; }
 
-We'll need to add some test data to the project to prove that everything is working.  Time to revisit 'Startup.cs' and add a new method:
-```csharp
-private ExampleContext CreateExampleDatabase()
-{
-    var context = new ExampleContext();
-    var liz = new Employee
+    public ExampleContext()
     {
-        FirstName = "Liz",
-        LastName = "Lemon",
-        Birthday = DateTimeOffset.Parse("1981-05-01"),
-        VacationDays = 0,
-        Vehicles = new List<Car>()
-    };
-    var firebird = new Car
-    {
-        Make = "Pontiac",
-        Model = "Firebird",
-        Year = 1981,
-        Color = Car.Colors.Blue
-    };
-    context.Cars.Add(firebird);
-    liz.Vehicles.Add(firebird);
-    context.Employees.Add(liz);
+        var firebird = new Car { Make = "Pontiac", Model = "Firebird", Year = 1981, Color = Colors.Blue };
+        var ferrari  = new Car { Make = "Ferrari N.V.", Model = "250 GTO", Year = 1962, Color = Colors.Red };
+        var cayman   = new Car { Make = "Porsche", Model = "Cayman", Year = 2005, Color = Colors.Yellow };
 
-    var jack = new Employee
-    {
-        FirstName = "Jack",
-        LastName = "Donaghy",
-        Birthday = DateTimeOffset.Parse("1957-07-12"),
-        VacationDays = 300,
-        Vehicles = new List<Car>()
-    };
-    var ferrari = new Car
-    {
-        Make = "Ferrari N.V.",
-        Model = "250 GTO",
-        Year = 1962,
-        Color = Car.Colors.Red
-    };
-    context.Cars.Add(ferrari);
-    jack.Vehicles.Add(ferrari);
-    var porsche = new Car
-    {
-        Make = "Porsche",
-        Model = "Cayman",
-        Year = 2005,
-        Color = Car.Colors.Yellow
-    };
-    context.Cars.Add(porsche);
-    jack.Vehicles.Add(porsche);
-    context.Employees.Add(jack);
+        var liz  = new Employee { FirstName = "Liz",  LastName = "Lemon",   Birthday = new DateTimeOffset(1981,5,1,0,0,0,TimeSpan.Zero), VacationDays = 0,   Vehicles = [firebird] };
+        var jack = new Employee { FirstName = "Jack", LastName = "Donaghy", Birthday = new DateTimeOffset(1957,7,12,0,0,0,TimeSpan.Zero), VacationDays = 300, Vehicles = [ferrari, cayman] };
 
-    return context;
-}
-```
-
-Now we need to introduce this data into the application as a dependency injection.  Modify Startup::ConfigureServices:
-```csharp
-// This method gets called by the runtime. Use this method to add services to the container.
-public void ConfigureServices(IServiceCollection services)
-{
-    var database = CreateExampleDatabase();
-    services.AddSingleton<ExampleContext>(database);
-}
-```
-
-And make sure this is injected into ExampleController via the constructor:
-```csharp
-[Route("api/example/")]
-public class ExampleController : Controller
-{
-    ExampleContext _context;
-    public ExampleController(ExampleContext context)
-    {
-        _context = context;
+        Employees = [liz, jack];
+        Cars = [firebird, ferrari, cayman];
     }
-    
-    ...
-```
-
-While we're here, lets add an endpoint that a user can use to query for data.
-```csharp
-[HttpGet, Route("employees")]
-public List<Employee> Employees()
-{
-    return _context.Employees;
 }
 ```
 
-Before we introduce Popcorn in depth, lets check that this all works, and demonstrate why we even *need* Popcorn in the first place.
-Postman will help us here.  Issue a 'GET' to '/api/example/employees'
-![Raw Api Response](QS.04.PostmanRawApi.png)
+## 5. Tell Popcorn which types are response-shaped
 
-We have all our data here! Great! Our entire heirarchy has been returned to us.
-But... what if we didn't actually *care* about the vehicles? That could be a ton of information that we don't need, using extra data and time.
-So let's add Popcorn and see how it makes us more efficient.
-
-If you haven't already, now would be a great time to visit the [Quick Start Guide](DotNetQuickStart.md) and make sure you've got Popcorn linked into 
-your project correctly.
-
-To utilize Popcorn we need to do three things (in the future, only one, so come back when v2 is released!).  
-Add two 'projections', which are the data types that format our outgoing data.  A projection is simply a class that reflects what an entity
-should look like before being sent to a client.  Check out this answer on [stack overflow](https://stackoverflow.com/a/3461116/169813) for a better description.
-You may be more familiar with the name [DTO, Data Transfer Object](https://en.wikipedia.org/wiki/Data_transfer_object), we simply prefer pronounceable names
-over acronyms.
-
-Create a 'Projections' folder in our solution, then add:
+Popcorn's generator discovers types through standard `System.Text.Json` `[JsonSerializable]`
+attributes. Create `AppJsonSerializerContext.cs`:
 
 ```csharp
-public class EmployeeProjection
-{
-	public string FirstName { get; set; }
-	public string LastName { get; set; }
+using System.Text.Json.Serialization;
+using Popcorn.Shared;
+using PopcornDemo.Models;
 
-	public DateTimeOffset? Birthday { get; set; }
-	public int? VacationDays { get; set; }
+namespace PopcornDemo;
 
-	public List<CarProjection> Vehicles { get; set; }
-}
+[JsonSerializable(typeof(ApiResponse<List<Employee>>))]
+[JsonSerializable(typeof(ApiResponse<List<Car>>))]
+internal partial class AppJsonSerializerContext : JsonSerializerContext { }
 ```
+
+List top-level response types — the generator walks nested types (like `Car` inside
+`Employee.Vehicles`) automatically.
+
+## 6. Wire up `Program.cs`
+
+Replace the generated `Program.cs` with:
+
 ```csharp
-public class CarProjection
+using System.Text.Json;
+using Popcorn.Shared;
+using PopcornDemo;
+using PopcornDemo.Models;
+
+var builder = WebApplication.CreateSlimBuilder(args);
+
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddSingleton<ExampleContext>();
+builder.Services.AddPopcorn();
+
+builder.Services.ConfigureHttpJsonOptions(o =>
 {
-	public string Model { get; set; }
-	public string Make { get; set; }
-	public int? Year { get; set; }
-	public string Color { get; set; }
-}
+    o.SerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonSerializerContext.Default);
+    o.SerializerOptions.AddPopcornOptions(); // installs generator-emitted converters
+});
+
+var app = builder.Build();
+app.UsePopcornExceptionHandler(); // unhandled exceptions → ApiError envelope
+
+app.MapGet("/employees", (IPopcornAccessor access, ExampleContext db) =>
+    access.CreateResponse(db.Employees));
+
+app.MapGet("/cars", (IPopcornAccessor access, ExampleContext db) =>
+    access.CreateResponse(db.Cars));
+
+app.Run();
 ```
 
-Okay, so you may be wondering why we even need these.  In the future we hope to skip projections where there's no advanced setup needed, but for now two things:
-1. We want to make all non-nullable types nullable, so they don't need to be included if not desired.
-2. We have to 'whitelist' properties.  Any property not on the destination type will not be included, even if explicitly requested.
-So if you have a property called 'SuperSecretEncryptionKeyNeverShare', you can exclude it from the projection and be sure that no Api client will see it.
+Three things worth noting:
 
-For advanced setup, as you'll see in later tutorials, projections give you a lot of control.
+- **`AddPopcorn()`** registers the per-request `IPopcornAccessor` that parses `?include=`.
+- **`AddPopcornOptions()`** is an extension emitted by the source generator; it installs one
+  `JsonConverter<T>` per type reachable from your `JsonSerializerContext`.
+- **`UsePopcornExceptionHandler()`** wraps unhandled exceptions in an `ApiResponse<T>` envelope
+  with `Success = false` and a populated `ApiError`. See
+  [the migration guide §6](../MigrationV7toV8.md#6-custom-response-envelope--error-handling)
+  for custom envelope shapes.
 
-Finally, we need to activate Popcorn on our pipeline and let it know about the projections.  Back in Startup.cs:
-```csharp
-// This method gets called by the runtime. Use this method to add services to the container.
-public void ConfigureServices(IServiceCollection services)
-{
-	var database = CreateExampleDatabase();
-	services.AddSingleton<ExampleContext>(database);
+`WebApplication.CreateSlimBuilder(args)` is the AOT-friendly host; if you don't plan to publish
+as AOT you can use `WebApplication.CreateBuilder(args)` instead.
 
-	// Add framework services.
-	services.AddMvc((mvcOptions) =>
-	{
-		mvcOptions.UsePopcorn((popcornConfig) => {
-			popcornConfig
-				.Map<Employee, EmployeeProjection>()
-				.Map<Car, CarProjection>();
-		});
-	});
-}
+## 7. Run it
+
+```bash
+dotnet run
 ```
 
-We let the MVC pipeline know we want to use Popcorn, then configure Popcorn with two mappings, Employee -> EmployeeProjection and Car -> CarProjection.
-Again, in the future we will have features to auto-detect simple mappings like these or obviate the need for a projection at all.
+Call the endpoint with no `?include=`:
 
+```
+GET /employees
+```
 
-To demonstrate, first call the same endpoint '/api/example/employees' and verify it looks the same:
-```javascript
-[
+```json
+{
+  "Success": true,
+  "Data": [
     {
-        "FirstName": "Liz",
-        "LastName": "Lemon",
-        "Birthday": "1981-05-01T00:00:00-04:00",
-        "VacationDays": 0,
-        "Vehicles": [
-            {
-                "Model": "Firebird",
-                "Make": "Pontiac",
-                "Year": 1981,
-                "Color": "Blue"
-            }
-        ]
+      "FirstName": "Liz",
+      "LastName": "Lemon",
+      "Birthday": "1981-05-01T00:00:00+00:00",
+      "VacationDays": 0,
+      "Vehicles": [
+        { "Make": "Pontiac", "Model": "Firebird", "Year": 1981, "Color": 2 }
+      ]
     },
-    {
-        "FirstName": "Jack",
-        "LastName": "Donaghy",
-        "Birthday": "1957-07-12T00:00:00-04:00",
-        "VacationDays": 300,
-        "Vehicles": [
-            {
-                "Model": "250 GTO",
-                "Make": "Ferrari N.V.",
-                "Year": 1962,
-                "Color": "Red"
-            },
-            {
-                "Model": "Cayman",
-                "Make": "Porsche",
-                "Year": 2005,
-                "Color": "Yellow"
-            }
-        ]
-    }
-]
+    { "FirstName": "Jack", "LastName": "Donaghy", ... }
+  ]
+}
 ```
 
-A few things to point out: The casing has changed due to our internal popcorn settings (FirstName instead of firstName).  
-Also, our Colors enumeration has gone from a numeric format (1,5) to textual (Red, Yellow), but this can all be configured to your tastes.
+The default is "everything" because we haven't applied any `[Default]` / `[Always]` attributes
+yet — see the [Default Includes tutorial](DotNetTutorialDefaultIncludes.md) for how to change
+that.
 
-To start seeing the real power of Popcorn, lets make a couple of advanced calls.  Maybe we only want our Employee's names? 
-Make a GET request to '/api/example/employees?include=[FirstName,LastName]':
-```javascript
-[
-    {
-        "FirstName": "Liz",
-        "LastName": "Lemon"
-    },
-    {
-        "FirstName": "Jack",
-        "LastName": "Donaghy"
-    }
-]
+## 8. Start asking for specific fields
+
 ```
-Now we only transfer the data we really need!  
-
-The include syntax can be referenced into sub-entities too.
-Try a GET request to '/api/example/employees?include=[FirstName,LastName,Vehicles[Make]]':
-```javascript
-[
-    {
-        "FirstName": "Liz",
-        "LastName": "Lemon",
-        "Vehicles": [
-            {
-                "Make": "Pontiac"
-            }
-        ]
-    },
-    {
-        "FirstName": "Jack",
-        "LastName": "Donaghy",
-        "Vehicles": [
-            {
-                "Make": "Ferrari N.V."
-            },
-            {
-                "Make": "Porsche"
-            }
-        ]
-    }
-]
+GET /employees?include=[FirstName,LastName]
 ```
-As you can see, you can use this syntax to make the response data as light or as deep as you need for any given situation.
 
+```json
+{
+  "Success": true,
+  "Data": [
+    { "FirstName": "Liz",  "LastName": "Lemon"   },
+    { "FirstName": "Jack", "LastName": "Donaghy" }
+  ]
+}
+```
+
+Nested includes work recursively:
+
+```
+GET /employees?include=[FirstName,Vehicles[Make]]
+```
+
+```json
+{
+  "Success": true,
+  "Data": [
+    { "FirstName": "Liz",  "Vehicles": [{ "Make": "Pontiac" }] },
+    { "FirstName": "Jack", "Vehicles": [{ "Make": "Ferrari N.V." }, { "Make": "Porsche" }] }
+  ]
+}
+```
+
+This is the point of Popcorn: the client decides exactly which fields to transfer, the server
+never materializes the rest.
+
+## Where to go next
+
+- [Include Parameter Syntax](DotNetTutorialIncludeParameterSyntax.md) — the full `?include=`
+  grammar, including `!all`, `!default`, and negation via `-Field`.
+- [Default Includes](DotNetTutorialDefaultIncludes.md) — `[Default]`, `[Always]`,
+  `[SubPropertyDefault("[Make,Model]")]` — control what a bare `?include=` request returns.
+- [Internal-Only Fields](DotNetTutorialInternalOnly.md) — `[Never]` for fields that must not
+  leave the server regardless of what the client asks for.
+- [Computed Fields](DotNetTutorialAdvancedProjections.md) — C# computed properties as the
+  v8 replacement for v7's `Translate<T>(...)` lambdas.
+- [Performance](../Performance.md) — benchmarked ratios vs raw `System.Text.Json` and v7.
+- [`PopcornAotExample`](../../dotnet/PopcornAotExample/) — reference project that publishes
+  with `PublishAot=True` + `PublishTrimmed=True`.

--- a/docs/dotnet/DotNetTutorialIncludeParameterSyntax.md
+++ b/docs/dotnet/DotNetTutorialIncludeParameterSyntax.md
@@ -4,6 +4,13 @@
 
 Popcorn's core feature is the ability to selectively include properties in API responses using the `include` parameter. This tutorial explains the syntax for the `include` parameter, including special references and property negation.
 
+> **Names in `?include=` are wire names, not C# names.** The names you list are matched
+> against the JSON property name the client sees on the wire — whichever comes first:
+> the `[JsonPropertyName("...")]` value, or the C# name normalized by your configured
+> `JsonNamingPolicy`. A response body `{"display_name": "..."}` is asked for as
+> `?include=[display_name]`. Requesting `?include=[DisplayName]` is treated as an unknown
+> name and the field is silently omitted.
+
 ## Basic Include Syntax
 
 The basic syntax for the `include` parameter is a comma-separated list of property names enclosed in square brackets:
@@ -91,13 +98,15 @@ This will include `Property1` and the nested properties `NestedProperty1` and `N
 
 ## Case Sensitivity
 
-Property names in the `include` parameter are case-sensitive. For example:
+Property names in the `include` parameter are case-sensitive and must match the wire name
+exactly. If your `JsonNamingPolicy` is `CamelCase`, a C# `DisplayName` property is emitted
+as `"displayName"` and must be requested as `?include=[displayName]`.
 
 ```
 ?include=[Name]
 ```
 
-Will include a property named `Name`, but not a property named `name`.
+Will match a wire-name property `Name`, but not `name`.
 
 ## Examples
 

--- a/docs/dotnet/DotNetTutorialInspectors.md
+++ b/docs/dotnet/DotNetTutorialInspectors.md
@@ -2,6 +2,20 @@
 
 [Table Of Contents](../../docs/TableOfContents.md)
 
+> ⚠️ **v7-only — dropped in v8.** `SetDefaultApiResponseInspector()` and `SetInspector(lambda)`
+> exist only in the v7 runtime-reflection line. v8 splits the two jobs cleanly:
+>
+> - **Response envelope shape** — declare a type decorated with `[PopcornEnvelope]` and marker
+>   attributes (`[PopcornPayload]`, `[PopcornError]`, `[PopcornSuccess]`). The generator emits a
+>   typed, reflection-free error writer for it.
+> - **Exception → envelope rewriting** — use `app.UsePopcornExceptionHandler()` middleware. It
+>   catches unhandled exceptions, looks up the configured envelope, and writes an
+>   `ApiError`-populated response with status 500.
+>
+> Full rationale + code samples: [MigrationV7toV8.md §6](../MigrationV7toV8.md#6-custom-response-envelope--error-handling).
+>
+> The tutorial below is preserved for v7 users still on that line.
+
 We feel that it is important for developers to have the opportunity to inspect their Popcorn response objects in a consistent fashion so that 
 they can format or process the responses according to the needs of their users. So with that we've extended "inspector" functionality to Popcorn users! 
 An example of an "inspector" that we often use would be setting a standard response object wrapper to make an

--- a/docs/dotnet/DotNetTutorialInternalOnly.md
+++ b/docs/dotnet/DotNetTutorialInternalOnly.md
@@ -1,76 +1,106 @@
-# [Popcorn](../../README.md) > [Documentation](../Documentation.md) > [DotNet](DotNetDocumentation.md) > Tutorial: Internal Only Attribute
+# [Popcorn](../../README.md) > [Documentation](../Documentation.md) > [DotNet](DotNetDocumentation.md) > Tutorial: Internal-Only Fields (`[Never]`)
 
 [Table Of Contents](../../docs/TableOfContents.md)
-We assume you've already learned the basics of configuring Popcorn in this tutorial. 
-If not, you should probably go back and complete [Getting Started](DotNetTutorialGettingStarted.md) first.
 
+If you're new to Popcorn, start with [Getting Started](DotNetTutorialGettingStarted.md) first.
 
-This tutorial will walk you through a few ways to protect undesired data from being passed to the client.
+Sometimes a model carries fields the API client should never see — a database-internal row
+version, a denormalized lookup key, a row-level secret. Popcorn gives you `[Never]`: a
+compile-time guarantee that the marked field is dropped during serialization, no matter what
+the client requests.
 
-### Overview
-We will achieve this using the [InternalOnly] attribute, which can be used on Classes, Properties and Methods.
+> **v7 → v8 note.** This attribute was called `[InternalOnly]` in v7. In v8 it's `[Never]`
+> (and lives in the `Popcorn` namespace). Semantics are otherwise unchanged.
+
+## Example
+
+Say we add a Social Security Number to our `Employee` model. Clients should never receive it:
+
 ```csharp
-[InternalOnly(throwException)]
+using Popcorn;
+
+public class Employee
+{
+    [Default] public string FirstName { get; set; } = "";
+    [Default] public string LastName  { get; set; } = "";
+
+    [Never] public string SocialSecurityNumber { get; set; } = "";
+}
 ```
-throwException is a bool parameter and the default value is true.
-* When used on classes:
-    * If true, an InternalOnlyViolationException will be thrown when you try to expand the class. 
-    * If false, you will receive a null object in response.
- * When used on methods and properties:
-    * If true an InternalOnlyViolationException will be thrown when you try to access the marked field or method. 
-    * If false, you will receive a null object for the requested property or method in response.
 
-### Example usage:
-Let's say  we store employee Social Security Numbers in our database. Under no circumstance do we want their socials to 
-be transmitted through our project using Popcorn. Enter the power of [InternalOnly]!
+The field is still a normal C# property — internal code can read and write it. It just gets
+dropped on the way out:
 
-First, we add the SocialSecurityNumber property to our Employee class and its projection.
-(Admittedly you could just not add the Social to the projection, but technically that is still a little vulnerable to 
-blind mapping and the like)
+```
+GET /employees?include=[FirstName,LastName,SocialSecurityNumber]
+```
+
+```json
+{
+  "Success": true,
+  "Data": [
+    { "FirstName": "Liz",  "LastName": "Lemon"   },
+    { "FirstName": "Jack", "LastName": "Donaghy" }
+  ]
+}
+```
+
+Note that the request *asked* for `SocialSecurityNumber` and the server simply omitted it — no
+error, no special handling. `[Never]` is stronger than "not in the default set"; it beats every
+other inclusion mechanism: `?include=[!all]` won't emit it, `[SubPropertyDefault("[SSN]")]`
+on the parent won't emit it, explicit `?include=[SocialSecurityNumber]` won't emit it.
+
+## When to use `[Never]` vs omitting the field entirely
+
+The safest way to keep a field off the wire is simply not to have it on the model the API
+returns. Two situations where `[Never]` is the better answer:
+
+1. **The model doubles as the internal data shape.** If your `Employee` class is also your
+   domain entity, you can't drop `SocialSecurityNumber` — internal code needs it. `[Never]`
+   lets the property stay in code and be invisible to the API.
+2. **Defense in depth.** Even if you also use a separate DTO, adding `[Never]` to sensitive
+   fields on the source model gives you an extra guardrail — if someone refactors and
+   accidentally returns the domain entity directly, the field still stays off the wire.
+
+If your API surface is naturally a separate DTO class and the source model never crosses the
+API boundary, you can skip `[Never]` — just omit the property from the DTO.
+
+## Why `[Never]` is better than "remove from projection"
+
+In v7 users would often strip sensitive fields by leaving them off the projection class. That
+worked, but it was easy to undermine accidentally (blind expansion would walk the source
+object, or a future refactor added a "quick" path that returned the entity directly). v8
+preserves `[Never]` explicitly at compile time because it's the one attribute whose guarantee
+is load-bearing for security.
+
+## Combining with `[SubPropertyDefault]`
+
+`[Never]` takes precedence over `[SubPropertyDefault]`. Even if a parent's `[SubPropertyDefault]`
+lists a `[Never]`-marked child property by name, the field stays hidden:
+
 ```csharp
 public class Employee
 {
-    public string FirstName { get; set; }
-    public string LastName { get; set; }
-
-    [InternalOnly(true)]
-    public int SocialSecurityNumber { get; set; }
-	...
+    [SubPropertyDefault("[Make,Model,Color,InternalVin]")]  // mentions InternalVin explicitly
+    public List<Car> Vehicles { get; set; } = new();
 }
 
-public class EmployeeProjection
+public class Car
 {
-    [IncludeByDefault]
-    public string FirstName { get; set; }
-    [IncludeByDefault]
-    public string LastName { get; set; }
+    public string Make  { get; set; } = "";
+    public string Model { get; set; } = "";
+    public Colors Color { get; set; }
 
-    public int SocialSecurityNumber { get; set; }
- }
-
-```
-
-Note that the SocialSecurityNumber property is marked as [InternalOnly] and set to throw an exception should it be called.
-**A key difference to remember here when compared to some other attributes is the source object is marked with the [InternalOnly] attibute and not its projection  
-- to make sure that the SocialSecurityNumber attribute isn't referenced accidentally in another place**
-
-Let's try making a request now to a GET employees endpoint and see what comes back when we specifically try to include SocialSecurityNumbers.
-```json
-http://localhost:49699/api/example/employees?include=[SocialSecurityNumber]
-{
-    "Success": false,
-    "ErrorCode": "Skyward.Popcorn.InternalOnlyViolationException",
-    "ErrorMessage": "Expand: SocialSecurityNumber property inside Employee class is marked [InternalOnly]",
-    "ErrorDetails": "Skyward.Popcorn.InternalOnlyViolationException: Expand: SocialSecurityNumber property inside Employee class is marked [InternalOnly]...
+    [Never] public string InternalVin { get; set; } = "";
 }
 ```
 
-An exception was thrown as expected!
-If we were to make a request to the GET employees method without a specific mention of SocialSecurityNumber, we would see a success response 
-with all of the other relevant employee information - just not the Social.
+`GET /employees?include=[Vehicles]` emits `Make` + `Model` + `Color` per car and no `InternalVin`.
+The substitution list is used to pick the default set; each child property still consults its
+own attribute stack before being emitted.
 
-It is up to you on how you will use the throwException parameter based on your needs.
+## See also
 
-**Don't Forget:** This attribute can be applied to Classes, Methods, and Properties so you have a lot of freedom here!
-
-And that's it, you can now use the [InternalOnly] attribute.
+- [Default Includes](DotNetTutorialDefaultIncludes.md) for `[Default]` and `[Always]`.
+- [Include Parameter Syntax](DotNetTutorialIncludeParameterSyntax.md) for the full `?include=`
+  grammar.

--- a/docs/dotnet/DotNetTutorialLazyLoading.md
+++ b/docs/dotnet/DotNetTutorialLazyLoading.md
@@ -1,24 +1,78 @@
-﻿# [Popcorn](../../README.md) > [Documentation](../Documentation.md) > [DotNet](DotNetDocumentation.md) > Tutorial: Lazy Loading
+# [Popcorn](../../README.md) > [Documentation](../Documentation.md) > [DotNet](DotNetDocumentation.md) > Tutorial: Lazy Loading
 
-[Lazy Loading](https://en.wikipedia.org/wiki/Lazy_loading) is a design pattern used to save processing power when creating or retrieving objects. It does this by only loading associated entities when required to do so.
+[Table Of Contents](../../docs/TableOfContents.md)
 
-An example of where lazy loading is beneficial is a list of authors on a blog site. There could be many authors and each author could have many blog posts associated with them. A view is created to show all authors that have
-a post on the site. Without lazy loading, you run the risk of pulling back all posts for all authors in that list. For a large list, this could be very expensive and wasteful if the purpose of the view is not to show posts
-but only author information. Lazy loading ensures that posts will only be retrieved when asked for by the user.
+[Lazy loading](https://en.wikipedia.org/wiki/Lazy_loading) is the pattern of deferring the
+materialization of related data until something actually asks for it. For web APIs, the
+classic motivation is an `Author` list page that *could* cascade into every author's blog
+posts but shouldn't, because nobody reads those posts on that page.
 
-Popcorn performs lazy loading for you on anything that is recognized as a [navigation property](https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/navigation-property). In order to use lazy loading, simply call the
-mapEntityFramwork() method on a PopcornConfiguration object.
+**In Popcorn v8, lazy loading works by construction — there is nothing to configure.**
+
+## How
+
+The source generator emits a `JsonConverter<T>` that writes one property at a time. If a
+property isn't in the `?include=` list (or doesn't match the default set), the generator's
+emitted code *never accesses the getter*. If that getter is a lazy-loaded EF navigation
+property, Entity Framework's change tracker never fires a load query, and the database is
+never touched.
+
+This is a straight consequence of v8's architecture: there is no intermediate projection
+step. The v7 reflection engine built a `Dictionary<string, object?>` describing the entire
+output before serializing — which meant every getter ran, which triggered every navigation
+load. v8 skips the dictionary and writes directly to `Utf8JsonWriter` property-by-property,
+so untouched getters stay untouched.
+
+## Example
 
 ```csharp
- var config = new PopcornConfiguration(_expander);
+public class Author
+{
+    [Default] public int Id { get; set; }
+    [Default] public string Name { get; set; } = "";
 
- config.MapEntityFramework<Project, ProjectProjection, TestModelContext>(TestModelContext.ConfigureOptions());
- config.MapEntityFramework<PopcornCoreTest.Models.Environment, EnvironmentProjection, TestModelContext>(TestModelContext.ConfigureOptions());
- config.MapEntityFramework<Credential, CredentialProjection, TestModelContext>(TestModelContext.ConfigureOptions());
-
+    // EF will lazy-load this when accessed.
+    public virtual ICollection<Post> Posts { get; set; } = new List<Post>();
+}
 ```
 
-Simply pass in two classes, a source type and a destination type, along with the DbContext used to load the data. In the above example, the source type is an Entity Framework entity and the destination type is 
-a projection used by Popcorn to return data in the format required for the client.
+```
+GET /authors
+→ default set: { Id, Name }. Posts getter is never called. Zero Post queries.
 
-That is it! Popcorn handles the lazy loading for you with this one call. Now you can load your data with confidence and ensure great performance for your clients.
+GET /authors?include=[Id,Name,Posts[Title]]
+→ Posts getter runs per author; EF fires one Post query per author (configurable via eager loading).
+```
+
+If the client doesn't ask for `Posts`, Popcorn doesn't fetch `Posts`. No framework flags, no
+`EnableLazyLoading(true)`, no `MapEntityFramework<S, P, Ctx>(...)` registration — the
+generator's emission pattern is what gets you the behavior.
+
+## What changed from v7
+
+The v7 API had a `MapEntityFramework<TSource, TProjection, TContext>()` configuration method
+that accepted an EF `DbContext` and wired up lazy-load support. **v8 has no equivalent** —
+and doesn't need one. Drop `MapEntityFramework` calls from your startup configuration during
+migration; everything continues to work.
+
+See [MigrationV7toV8.md §7](../MigrationV7toV8.md#7-projections-replacing-mapentityframework)
+for the full projection-pattern discussion.
+
+## Caveats
+
+- **Lazy loading requires EF proxies.** You still need to enable them at the EF level
+  (`UseLazyLoadingProxies()` on the `DbContextOptionsBuilder`). Popcorn does not change how
+  EF loads; it only changes which getters run.
+- **Eager-loaded navigation properties are always materialized.** If your EF query uses
+  `.Include(a => a.Posts)`, `Posts` is already in memory — Popcorn will still honor `?include=`
+  and omit it from the response, but the DB round-trip has already happened. Use lazy loading
+  (or a projection at the query layer) when cost matters.
+- **N+1 is still N+1.** If you lazy-load `Posts` inside a loop of 500 authors, that's 500
+  queries. Popcorn skipping the fetch when the client doesn't ask for `Posts` is what keeps
+  you out of the N+1 zone in the common case — but if a client does ask for it, plan for the
+  query count.
+
+## See also
+
+- [Default Includes](DotNetTutorialDefaultIncludes.md) for controlling what a bare request returns.
+- [Performance](../Performance.md) for the benchmarked cost of selective inclusion.

--- a/docs/dotnet/DotNetTutorialSorting.md
+++ b/docs/dotnet/DotNetTutorialSorting.md
@@ -2,6 +2,27 @@
 
 [Table Of Contents](../TableOfContents.md)
 
+> ⚠️ **v7-only — dropped in v8.** Built-in `?sort=…&sortDirection=…` handling does not exist
+> in v8. Sorting was very rarely used in practice, and when it was used the constraints (one
+> parameter, case-sensitive, top-level only) usually pushed callers to endpoint-level sorting
+> anyway. v8 asks you to handle it there directly:
+>
+> ```csharp
+> app.MapGet("/cars", (IPopcornAccessor access, string? sort, string? direction) =>
+> {
+>     var cars = _context.Cars.AsQueryable();
+>     cars = (sort, direction) switch
+>     {
+>         ("Model", "Descending") => cars.OrderByDescending(c => c.Model),
+>         ("Model", _)            => cars.OrderBy(c => c.Model),
+>         _                       => cars
+>     };
+>     return access.CreateResponse(cars.ToList());
+> });
+> ```
+>
+> The tutorial below is preserved for v7 users still on that line.
+
 This is a more advanced tutorial - we recommend you read [Getting Started](DotNetTutorialGettingStarted.md) and our other tutorials first to familiarize
 yourself with Popcorn. 
 

--- a/docs/dotnet/DotNetTutorialWildcardIncludes.md
+++ b/docs/dotnet/DotNetTutorialWildcardIncludes.md
@@ -2,149 +2,137 @@
 
 [Table Of Contents](../../docs/TableOfContents.md)
 
-With Popcorn, you have the ability to set [Default Includes](DotNetTutorialDefaultIncludes.md) and make 
-specific ?include=[...] requests with your API calls to condense response objects. There is also a wildcard option "*" that can be sent with the ?include 
-statement to get *all* non-null values from an endpoint, regardless of the defaults.
+Popcorn's `?include=` grammar supports two wildcard keywords: `!all` and `!default`. Both are
+prefixed with `!` (not `-` — that prefix is reserved for [negation](DotNetTutorialIncludeParameterSyntax.md)).
 
-Let's go through an example of what that looks like in action:
+> **v7 → v8 note.** In v7 you could use `*` as a wildcard (`?include=[*]`). In v8 the wildcard
+> is **`!all`**. If you're migrating a client, update the URLs.
+
+## `!all` — every available field
+
+`!all` includes every property on the target type (minus anything marked `[Never]`, which still
+wins). Useful for admin screens that need the full record without spelling out every field.
+
+Model:
+
 ```csharp
+using Popcorn;
+
 public class Employee
 {
-    public string FirstName { get; set; }
-    public string LastName { get; set; }
-
-    [InternalOnly(true)]
-    public long SocialSecurityNumber { get; set; }
+    [Default] public string FirstName { get; set; } = "";
+    [Default] public string LastName  { get; set; } = "";
 
     public DateTimeOffset Birthday { get; set; }
-    public EmploymentType Employment { get; set; }
     public int VacationDays { get; set; }
 
-    public List<Car> Vehicles { get; set; }
+    [Never] public string SocialSecurityNumber { get; set; } = "";
 
-    public List<Car> GetInsuredCars() {
-        return Vehicles.Where(c => c.Insured == true).ToList();
-    }
+    public List<Car> Vehicles { get; set; } = new();
 }
+```
 
-public class EmployeeProjection
+Bare request (returns default set):
+
+```
+GET /employees
+→ { FirstName, LastName }
+```
+
+Wildcard request:
+
+```
+GET /employees?include=[!all]
+```
+
+```json
 {
-    [IncludeByDefault]
-    public string FirstName { get; set; }
-    [IncludeByDefault]
-    public string LastName { get; set; }
-    public string FullName { get; set; }
-
-    public long? SocialSecurityNumber { get; set; }
-
-    public string Birthday { get; set; }
-    public int? VacationDays { get; set; }
-    public EmploymentType? Employment { get; set; }
-
-    [SubPropertyIncludeByDefault("[Make,Model,Color]")]
-    public List<CarProjection> Vehicles { get; set; }
-
-    public List<CarProjection> InsuredVehicles { get; set; }
+  "Success": true,
+  "Data": [
+    {
+      "FirstName": "Liz",
+      "LastName": "Lemon",
+      "Birthday": "1981-05-01T00:00:00+00:00",
+      "VacationDays": 0,
+      "Vehicles": [...]
+    },
+    { "FirstName": "Jack", "LastName": "Donaghy", ... }
+  ]
 }
 ```
 
-You'll see on the EmployeeProjection the FirstName and LastName properties are set to be included by default. 
-If we make a generic request to a GET Employees endpoint we see the following response
-```javascript
-http://localhost:50353/api/example/employees
+`SocialSecurityNumber` is still absent — `[Never]` beats `!all`. That's the point: `[Never]`
+is the one attribute whose guarantee is load-bearing for security.
 
+## `!default` — the configured default set
+
+`!default` is the default set explicitly invoked. It's only interesting in combination with
+other include tokens, since a bare request already yields the default set:
+
+```
+GET /employees?include=[!default,Birthday]
+→ FirstName, LastName, and Birthday
+```
+
+Handy when you want "the default set plus one extra field" without respelling the defaults.
+
+## Negation: `!all,-Field` and `!default,-Field`
+
+Both wildcards combine with `-FieldName` to drop specific fields:
+
+```
+GET /employees?include=[!all,-Birthday]
+→ everything except Birthday
+
+GET /employees?include=[!default,-LastName]
+→ default set without LastName
+```
+
+Negating an `[Always]`-marked field is a silent no-op — `[Always]` wins.
+
+## Wildcards on nested sub-entities
+
+Wildcards also work inside nested brackets:
+
+```
+GET /employees?include=[FirstName,Vehicles[!all]]
+```
+
+```json
 {
-    "Success": true,
-    "Data": [
-        {
-            "FirstName": "Liz",
-            "LastName": "Lemon",
-            "Employment": "Employed"
-        },
-        {
-            "FirstName": "Jack",
-            "LastName": "Donaghy",
-            "Employment": "Employed"
-        }
-    ]
+  "Success": true,
+  "Data": [
+    {
+      "FirstName": "Liz",
+      "Vehicles": [
+        { "Make": "Pontiac", "Model": "Firebird", "Year": 1981, "Color": 2 }
+      ]
+    },
+    ...
+  ]
 }
 ```
 
-If, for example, we actually want to know everything about our employees to render all of their information on an admin page, we can make the following call
-**Note: We ignored the SocialSecurityNumber because it's marked InternalOnly**
-```javascript
-http://localhost:49699/api/example/employees?include=[FirstName,LastName,FullName,Birthday,VacationDays,Employment,Vehicles,InsuredVehicles]
+This is particularly useful when the parent has a tight default set but you want to walk the
+full child shape.
+
+## Unknown field names are silently ignored
+
+Typos or fields that don't exist on the target type are treated as no-ops:
+
+```
+GET /employees?include=[FirstName,Whoops]
+→ { FirstName }
 ```
 
-While adding properties dynamically to an include statement with some nice front end logic isn't that difficult to maintain, 
-making calls that include long strings of includes can get cumbersome when debugging, making one off requests, testing, or in simple use cases.
+This is intentional — clients evolve at a different cadence from servers, and a 500 on a
+renamed field breaks more things than it helps. Names must resolve to the **wire name** (the
+`[JsonPropertyName("…")]` argument if present, otherwise the C#-name normalized by your
+`JsonNamingPolicy`). See [Include Parameter Syntax](DotNetTutorialIncludeParameterSyntax.md)
+for the full contract.
 
-The wildcard "*" can be used as a replacement to return all non-null values on response objects:
-```javascript
-http://localhost:49699/api/example/employees?include=[*]
+## See also
 
-{
-    "Success": true,
-    "Data": [
-        {
-            "FirstName": "Liz",
-            "LastName": "Lemon",
-            "FullName": "Liz Lemon",
-            "Birthday": "05/01/1981",
-            "VacationDays": 0,
-            "Employment": "FullTime",
-            "Vehicles": [
-                {
-                    "Model": "Firebird",
-                    "Make": "Pontiac",
-                    "Color": "Blue",
-                    "Insured": false
-                }
-            ],
-            "InsuredVehicles": [
-                {
-                    "Model": "Firebird",
-                    "Make": "Pontiac",
-                    "Year": 1981,
-                    "Insured": false
-                }
-            ]
-        },
-        {
-            "FirstName": "Jack",
-            "LastName": "Donaghy",
-            "FullName": "Jack Donaghy",
-            "Birthday": "07/12/1957",
-            "VacationDays": 300,
-            "Employment": "PartTime",
-            "Vehicles": [
-                {
-                    "Model": "250 GTO",
-                    "Make": "Ferrari N.V.",
-                    "Color": "Red",
-                    "Insured": false
-                },
-                {
-                    "Model": "Cayman",
-                    "Make": "Porsche",
-                    "Color": "Yellow",
-                    "Insured": false
-                }
-            ],
-            "InsuredVehicles": [
-                {
-                    "Model": "Cayman",
-                    "Make": "Porsche",
-                    "Year": 2005,
-                    "Insured": false
-                }
-            ]
-        }
-    ]
-}
-```
-
-#### Important Notes
-+ The wildcard can be used on an expandable sub property as well (like Vehicles in the example above)
-	+ It also can be used on BlindExpanded or mapped objects, assuming BlindExpansion is enabled
-+ Nesting wildcards will throw an error i.e. "?include=[FirstName, *, LastName]"
+- [Include Parameter Syntax](DotNetTutorialIncludeParameterSyntax.md) — the complete grammar.
+- [Default Includes](DotNetTutorialDefaultIncludes.md) — shaping what the default set is.
+- [Internal-Only Fields](DotNetTutorialInternalOnly.md) — `[Never]` and why wildcards can't override it.

--- a/docs/dotnet/Updates.md
+++ b/docs/dotnet/Updates.md
@@ -2,99 +2,25 @@
 
 [Table Of Contents](../TableOfContents.md)
 
-## Documentation Review Plan
+> Historical planning document from the v7 → v8 documentation overhaul. The work it describes
+> has shipped: core tutorials now target v8 source-generator patterns, dropped-feature
+> tutorials carry top-of-file deprecation banners pointing at the v8 replacement, and the
+> migration guide ([MigrationV7toV8.md](../MigrationV7toV8.md)) is the primary upgrade path.
+>
+> For the current documentation state, start from the [Table of Contents](../TableOfContents.md).
+> For what's coming next, see the [Roadmap](../../roadmap.md).
 
-### Outdated Examples to Update
-1. Runtime Mapping Configuration
-   - DotNetQuickStart.md - Update to show source generator approach
-   - DotNetTutorialGettingStarted.md - Revise for compile-time pattern
-   - DotNetTutorialAdvancedProjections.md - Update factory patterns
-   - DotNetTutorialBlindExpansion.md - Consider deprecation or revision
+## What shipped
 
-### New Patterns to Document
-1. Source Generator Attributes
-   - `[Pop]` attribute usage and configuration
-   - Property inclusion/exclusion rules
-   - Default value handling
-   - Inheritance scenarios
-
-2. Performance Considerations
-   - Compile-time vs runtime tradeoffs
-   - Memory allocation patterns
-   - AOT compilation support
-   - Native compilation scenarios
-
-3. Best Practices
-   - When to use source generation vs runtime
-   - Project organization with generated code
-   - Debugging generated expansions
-   - Error handling and diagnostics
-
-## Implementation Timeline
-
-### Phase 1: Legacy Documentation Updates
-1. Add notices to existing tutorials about runtime vs compile-time approaches
-2. Update examples to show both patterns where applicable
-3. Mark deprecated patterns and provide migration paths
-4. Review and update all code samples for accuracy
-
-### Phase 2: New Documentation Creation
-1. Source Generator Core Documentation
-   - Architecture overview
-   - Implementation details
-   - Configuration options
-   - Performance characteristics
-
-2. Migration Guide
-   - Step-by-step migration process
-   - Common pitfalls and solutions
-   - Testing strategies
-   - Validation approaches
-
-3. New Features Documentation
-   - AOT compilation support
-   - Native compilation scenarios
-   - Performance optimization guides
-   - Tooling integration
-
-### Phase 3: Example Updates
-1. Create new example projects
-   - Basic source generator usage
-   - Advanced scenarios
-   - Performance benchmarks
-   - Migration examples
-
-2. Update existing examples
-   - Add source generator versions
-   - Include performance comparisons
-   - Document tradeoffs
-
-## Priority Updates
-
-1. Quick Start Guide
-   - New getting started path focusing on source generation
-   - Clear explanation of benefits
-   - Simple, complete example
-   - Common pitfalls to avoid
-
-2. Core Concepts
-   - Shift focus to compile-time expansion
-   - Explain attribute-based configuration
-   - Document type handling
-   - Cover error scenarios
-
-3. Advanced Features
-   - Complex type scenarios
-   - Custom expansion rules
-   - Integration patterns
-   - Performance optimization
-
-## Conclusion
-
-This documentation update plan aims to:
-1. Preserve valuable existing content while clearly marking legacy approaches
-2. Introduce new source generator patterns and best practices
-3. Provide clear migration paths for existing users
-4. Emphasize performance and maintainability improvements
-
-Progress will be tracked in the repository's issues, with each documentation update tied to specific milestones. Community feedback and contributions will be actively incorporated throughout the process.
+- New v8-focused tutorials: [DotNet Quick Start](DotNetQuickStart.md),
+  [Getting Started](DotNetTutorialGettingStarted.md),
+  [Default Includes](DotNetTutorialDefaultIncludes.md),
+  [Include Parameter Syntax](DotNetTutorialIncludeParameterSyntax.md),
+  [Wildcard Includes](DotNetTutorialWildcardIncludes.md),
+  [Internal Only](DotNetTutorialInternalOnly.md),
+  [Lazy Loading](DotNetTutorialLazyLoading.md),
+  [Advanced Projections](DotNetTutorialAdvancedProjections.md).
+- [Migration guide](../MigrationV7toV8.md) covering every breaking change.
+- [Performance page](../Performance.md) with benchmarked ratios vs raw STJ and v7 reflection.
+- v7-only tutorials carry deprecation banners and survive as reference material for users still
+  on the reflection line.


### PR DESCRIPTION
## Summary

Two focused commits:

- **Wire real release workflow** ([0c15fb8](../commit/0c15fb8)) — fixes the broken \`/^release/\` tag trigger in \`main.yml\`. Tagging \`release/vX.Y.Z\` now:
  1. Extracts SemVer, validates format
  2. Packs both v8 packages with \`-p:Version=X.Y.Z\` (csproj \`<Version>\` overridden at pack time)
  3. Pushes \`.nupkg\` + \`.snupkg\` to NuGet with \`--skip-duplicate\`
  4. Creates a GitHub Release with auto-generated notes + packages attached
  5. Best-effort syncs csproj \`<Version>\` back to master (continues on failure so branch protection doesn't block a release)

- **Docs refresh** ([b64dd25](../commit/b64dd25)) — the core tutorials in \`docs/\` still described the v7 runtime-reflection API. This pass rewrites them for the v8 source-generator line, adds a "reflection → source-generator" aside in README.md, adds top-of-file deprecation banners on the 6 v7-only tutorials (Authorizers / Sorting / Inspectors / Contexts / ExpandFrom / BlindExpansion) with pointers to the v8 replacement in \`MigrationV7toV8.md\`, and updates nav/indexes to match.

## Test plan

- [x] YAML syntax valid for \`main.yml\` (\`python -c "import yaml; yaml.safe_load(...)"\`)
- [x] No dead internal links introduced (\`TableOfContents.md\` / \`DotNetDocumentation.md\` cross-checked against the remaining tutorial set)
- [x] CI green on this branch (tests, AOT, benchmark gate) — previous push passed all 6 before the dedup change
- [ ] After merge: operator tags \`release/v8.0.0-preview.1\` to exercise the release workflow end-to-end

## Release secrets

The release workflow reads \`secrets.SKYWARDNUGETAPIKEY\`. Before the first tag, confirm (or set) that repo secret at <https://github.com/SkywardApps/popcorn/settings/secrets/actions>. API key scope on nuget.org: "Push new packages and package versions" with glob \`Skyward.Api.Popcorn.SourceGen*\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)