### PR TITLE
Bump Actions past Node 20, add analyzer release tracking, fix CS8604

### DIFF
--- a/.github/workflows/aot-ci.yml
+++ b/.github/workflows/aot-ci.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build AOT container image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: dotnet
           file: dotnet/PopcornAotExample/Dockerfile

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,15 +33,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET SDK 8.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('dotnet/**/*.csproj') }}
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload BDN artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-results
           path: dotnet/benchmarks/SerializationPerformance/BenchmarkDotNet.Artifacts/results/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout tagged commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # SourceLink needs full history to resolve commit hashes
 
@@ -49,7 +49,7 @@ jobs:
           echo "Detected version: $VERSION"
 
       - name: Setup .NET SDK 8.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,17 +24,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET SDK 8.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           # Test projects target net8.0. Install the matching SDK so we don't rely on
           # DOTNET_ROLL_FORWARD.
           dotnet-version: 8.0.x
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('dotnet/**/*.csproj') }}
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: dotnet/TestResults/*.trx

--- a/dotnet/Popcorn.SourceGenerator/AnalyzerReleases.Shipped.md
+++ b/dotnet/Popcorn.SourceGenerator/AnalyzerReleases.Shipped.md
@@ -1,0 +1,17 @@
+; Shipped analyzer releases.
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+## Release 8.0.0
+
+### New Rules
+
+Rule ID | Category        | Severity | Notes
+--------|-----------------|----------|----------------------------------------------------------
+JSG001  | SourceGenerator | Error    | Source generation error — generator threw during emission.
+JSG002  | SourceGenerator | Warning  | Informational log from the generator.
+JSG003  | SourceGenerator | Warning  | Envelope missing [PopcornPayload] — middleware will fall back to default shape.
+JSG004  | SourceGenerator | Warning  | Envelope has duplicate Popcorn marker attributes.
+JSG005  | SourceGenerator | Warning  | Envelope [PopcornPayload] property should be Pop&lt;T&gt;.
+JSG006  | SourceGenerator | Warning  | Envelope [PopcornError] property should be ApiError or ApiError?.
+JSG007  | SourceGenerator | Warning  | Envelope nested inside a generic outer type is not supported.
+JSG008  | SourceGenerator | Warning  | Property typed as object / abstract class / interface — AOT non-starter.

--- a/dotnet/Popcorn.SourceGenerator/AnalyzerReleases.Unshipped.md
+++ b/dotnet/Popcorn.SourceGenerator/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,6 @@
+; Unshipped analyzer releases.
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+; When a new diagnostic is added, list it here (same table format as Shipped.md under a
+; "### New Rules" heading). At the next release, move the entry to Shipped.md under a new
+; "## Release X.Y.Z" header.

--- a/dotnet/Popcorn.SourceGenerator/ExpanderGenerator.cs
+++ b/dotnet/Popcorn.SourceGenerator/ExpanderGenerator.cs
@@ -1061,7 +1061,7 @@ public static class PopcornJsonOptionsExtension
         private static string CreateArraySerializer(HashSet<string> allTypeNames, INamedTypeSymbol? itemType)
         {
             string internalSerializationCode;
-            var propertyTypeName = itemType?.ToDisplayString().Replace("?", "");
+            var propertyTypeName = itemType?.ToDisplayString().Replace("?", "") ?? "";
             if (allTypeNames.Contains(propertyTypeName))
             {
                 if (TargetEmitsInner(itemType))

--- a/dotnet/Popcorn.SourceGenerator/Popcorn.SourceGenerator.csproj
+++ b/dotnet/Popcorn.SourceGenerator/Popcorn.SourceGenerator.csproj
@@ -11,6 +11,13 @@
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IsRoslynComponent>true</IsRoslynComponent>
 
+    <!-- RS2003 fires on each shipped-rule entry because this project is an IIncrementalGenerator,
+         not a DiagnosticAnalyzer — source generators don't expose SupportedDiagnostics, so the
+         release-tracking validator can't match the rule IDs to an analyzer. The tracking files
+         exist purely as shipped-diagnostic documentation (silences the RS2008 "enable tracking"
+         warning the consumer-build sees). Safe to suppress at the project level. -->
+    <NoWarn>$(NoWarn);RS2003</NoWarn>
+
     <PackageId>Skyward.Api.Popcorn.SourceGen</PackageId>
     <Version>8.0.0-preview.1</Version>
     <Authors>Skyward App Company, LLC</Authors>
@@ -59,6 +66,13 @@
 
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
     <None Include="..\..\README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <!-- Analyzer release tracking — silences RS2008 ("Enable analyzer release tracking for rule JSGxxx").
+       AdditionalFiles makes the Microsoft.CodeAnalysis.Analyzers release-tracking analyzer read them. -->
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Cleanup pass addressing the three warning categories the 8.0.0-preview.1 release run surfaced.

## Changes

### GitHub Actions bumps (fixes Node 20 deprecation)

The release run warned that \`actions/checkout@v4\` and \`actions/setup-dotnet@v4\` still run on Node 20 (deprecation enforcement starts June 2026). Bumping all Actions to the latest majors at once:

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-dotnet | v4 | v5 |
| actions/cache | v4 | v5 |
| actions/upload-artifact | v4 | v7 |
| docker/setup-buildx-action | v3 | v4 |
| docker/build-push-action | v5 | v7 |

### Analyzer release tracking

The release run fired \`RS2008\` for every generator diagnostic (JSG001–JSG008) asking them to be tracked. Added \`AnalyzerReleases.Shipped.md\` (all eight rules under \`## Release 8.0.0\`) and a stub \`AnalyzerReleases.Unshipped.md\` for future additions. Registered both as \`<AdditionalFiles>\` so the tracking analyzer reads them.

Side-effect: the tracker then fired \`RS2003\` ("rule not declared on any analyzer") for each rule, because \`IIncrementalGenerator\` has no \`SupportedDiagnostics\` surface. Suppressed at project scope with a comment explaining why.

### CS8604 nullref fix

\`ExpanderGenerator.cs:1065\` computed \`propertyTypeName = itemType?.ToDisplayString().Replace("?", "")\` and passed it directly to \`HashSet<string>.Contains\` — potentially-null argument. Applied the same \`?? ""\` coalesce already in use on the sibling function at line 1128.

## Test plan

- [x] \`dotnet build dotnet/Popcorn.SourceGenerator/Popcorn.SourceGenerator.csproj -c Release\` — 0 warnings, 0 errors
- [ ] CI \`dotnet test\` — 182 passing / 2 skipped maintained (local tests can't run — no .NET 8 runtime on this dev box, but CI installs it)
- [ ] CI AOT endpoint verification — unchanged code path, should be identical result
- [ ] CI benchmarks (relative-perf gate) — zero generator output change expected from the nullref fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)